### PR TITLE
테마 게시판 작업 - 파트2 (issue: #12)

### DIFF
--- a/src/components/common/Text.tsx
+++ b/src/components/common/Text.tsx
@@ -1,0 +1,37 @@
+/**
+ * Figma 기반으로 작성된 Text 컴포넌트
+ * @param as 태그 이름
+ * @param variant 텍스트 스타일
+ * @param children 텍스트 내용
+ * @param className 추가 클래스 이름
+ */
+
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
+import { TYPOGRAPHY, type TypographyVariant } from "../../constants/typography";
+import { cn } from "../../utils/cn";
+
+interface ITextOwnProps<T extends ElementType> {
+  as?: T
+  variant: TypographyVariant
+  children: ReactNode
+  className?: string
+}
+
+type ITextProps<T extends ElementType> = ITextOwnProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof ITextOwnProps<T>>;
+
+export default function Text<T extends ElementType = "span">({
+  as,
+  variant,
+  children,
+  className,
+  ...props
+}: ITextProps<T>) {
+  const Component = as ?? "span";
+
+  return (
+    <Component className={cn(TYPOGRAPHY[variant], className)} {...props}>
+      {children}
+    </Component>
+  );
+}

--- a/src/components/community/CommunityPostGridItem.tsx
+++ b/src/components/community/CommunityPostGridItem.tsx
@@ -3,11 +3,26 @@
  * @param item 게시글 아이템
  */
 import type { ICommunityPostItme } from "../../types/community/post";
+import { Link } from "react-router-dom";
 
 interface ICommunityPostGridItemProps {
   item: ICommunityPostItme;
 }
 
 export default function CommunityPostGridItem({ item }: ICommunityPostGridItemProps) {
-  return <div className="h-[120px] rounded-[2px] bg-secondary-100" />;
+  return (
+    <Link
+      to={`/community/${item.boardId}`}
+      className="block h-[120px] overflow-hidden rounded-[2px] bg-secondary-100"
+      aria-label={`${item.title} 상세 페이지로 이동`}
+    >
+      {item.previewImageUrl ? (
+        <img src={item.previewImageUrl} alt={item.title} className="h-full w-full object-cover" />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-[12px] text-secondary-400">
+          미리보기
+        </div>
+      )}
+    </Link>
+  );
 }

--- a/src/components/community/CommunityPostGridItem.tsx
+++ b/src/components/community/CommunityPostGridItem.tsx
@@ -1,0 +1,13 @@
+/**
+ * 커뮤니티 게시글 목록 아이템 컴포넌트
+ * @param item 게시글 아이템
+ */
+import type { ICommunityPostItme } from "../../types/community/post";
+
+interface ICommunityPostGridItemProps {
+  item: ICommunityPostItme;
+}
+
+export default function CommunityPostGridItem({ item }: ICommunityPostGridItemProps) {
+  return <div className="h-[120px] rounded-[2px] bg-secondary-100" />;
+}

--- a/src/constants/typography.ts
+++ b/src/constants/typography.ts
@@ -1,0 +1,28 @@
+export const TYPOGRAPHY = {
+  EXTRA_BOLD_17: 'text-[17px] font-extrabold',
+
+  BOLD_18: 'text-[18px] font-bold',
+  BOLD_16: 'text-[16px] font-bold',
+  BOLD_15: 'text-[15px] font-bold',
+
+  SEMIBOLD_20: 'text-[20px] font-semibold',
+  SEMIBOLD_16: 'text-[16px] font-semibold',
+  SEMIBOLD_15: 'text-[15px] font-semibold',
+
+  MEDIUM_16: 'text-[16px] font-medium',
+  MEDIUM_15: 'text-[15px] font-medium',
+  MEDIUM_14: 'text-[14px] font-medium',
+  MEDIUM_12: 'text-[12px] font-medium',
+
+  REGULAR_15: 'text-[15px] font-normal',
+  REGULAR_14: 'text-[14px] font-normal',
+  REGULAR_12: 'text-[12px] font-normal',
+  REGULAR_10: 'text-[10px] font-normal',
+
+  LIGHT_17: 'text-[17px] font-light',
+  LIGHT_15: 'text-[15px] font-light',
+  LIGHT_14: 'text-[14px] font-light',
+  LIGHT_12: 'text-[12px] font-light',
+} as const
+
+export type TypographyVariant = keyof typeof TYPOGRAPHY

--- a/src/layouts/BottomTabBar.tsx
+++ b/src/layouts/BottomTabBar.tsx
@@ -7,6 +7,7 @@ import HomeActiveIcon from "../components/icons/bottom-tab-menu/bottom-home-acti
 import CommunityActiveIcon from "../components/icons/bottom-tab-menu/bottom-community-active.png";
 import NotificationActiveIcon from "../components/icons/bottom-tab-menu/bottom-notify-active.png";
 import ProfileActiveIcon from "../components/icons/bottom-tab-menu/bottom-profile-active.png";
+import Text from "../components/common/Text";
 
 /**
  * 바텀 탭 메뉴 컴포넌트 인터페이스
@@ -43,13 +44,12 @@ interface IBottomTabItem {
  * @returns 탭 메뉴 아이템
  */
 function BottomTabBarItem({ iconSrc, iconSrcActive, text, href, isActive = false }: IBottomTabItem) {
-  const textClassName = `text-[12px]`
   const iconClassName = `h-5 w-5 ${isActive ? "opacity-100" : "opacity-90"}`
 
   const content = (
     <>
       <img src={isActive ? iconSrcActive : iconSrc} alt={text} className={iconClassName} />
-      <span className={textClassName}>{text}</span>
+      <Text variant="REGULAR_12">{text}</Text>
     </>
   )
 

--- a/src/layouts/MobileHeader.tsx
+++ b/src/layouts/MobileHeader.tsx
@@ -1,4 +1,5 @@
 import HeaderIcon from "../components/icons/header/header.png";
+import Text from "../components/common/Text";
 
 interface IMobileHeaderProps {
   title: string
@@ -6,10 +7,10 @@ interface IMobileHeaderProps {
 
 export default function MobileHeader({ title }: IMobileHeaderProps) {
   return (
-    <header className="sticky top-0 z-10 bg-white px-4 pt-10">
-      <div className="flex items-center justify-center gap-3 text-[15px] font-semibold">
+    <header className="shrink-0 bg-white px-4 pt-10">
+      <div className="flex items-center justify-center gap-3">
         <img src={HeaderIcon} alt="header" className="h-4 w-5" />
-        <span>{title}</span>
+        <Text variant="SEMIBOLD_15">{title}</Text>
       </div>
     </header>
   )

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -7,11 +7,12 @@ export default function MobileLayout() {
   const isHome: boolean = pathname === "/"
   const isCommunity: boolean = pathname.startsWith("/community")
   const hasHeader: boolean = isHome || isCommunity
+  const headerTitle: string = isCommunity ? "테마 커뮤니티" : "고정 헤더"
 
   return (
     <div className="flex min-h-screen items-start justify-center bg-white py-4">
       <div className="relative flex h-[700px] w-[340px] flex-col overflow-hidden border border-secondary-200">
-        {hasHeader && <MobileHeader title="고정 헤더" />}
+        {hasHeader && <MobileHeader title={headerTitle} />}
 
         <div className="scrollbar-hidden flex-1 overflow-y-auto pb-16">
           <Outlet />

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -10,9 +10,10 @@ export default function MobileLayout() {
 
   return (
     <div className="flex min-h-screen items-start justify-center bg-white py-4">
-      <div className="relative h-[700px] w-[340px] overflow-hidden border border-secondary-200">
-        <div className="scrollbar-hidden h-full overflow-y-auto pb-16">
-          {hasHeader && <MobileHeader title="고정 헤더" />}
+      <div className="relative flex h-[700px] w-[340px] flex-col overflow-hidden border border-secondary-200">
+        {hasHeader && <MobileHeader title="고정 헤더" />}
+
+        <div className="scrollbar-hidden flex-1 overflow-y-auto pb-16">
           <Outlet />
         </div>
 

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -1,18 +1,23 @@
 import CommunityPostGridItem from "../../components/community/CommunityPostGridItem";
 import type { ICommunityPostItme } from "../../types/community/post";
+import Text from "../../components/common/Text";
 
 const postPlaceholders = Array.from({ length: 12 }) as ICommunityPostItme[];
 
 export default function Community() {
   return (
     <>
-        <div className="sticky top-[63px] z-10 grid grid-cols-2 text-center text-[14px] font-bold bg-white">
-          <button className="border-b-2 border-primary py-2 text-primary">활동</button>
-          <button className="border-b-2 border-secondary-300 py-2 text-secondary-300">키워드</button>
+        <div className="sticky top-0 z-10 grid grid-cols-2 bg-white text-center text-[14px] font-bold">
+          <button className="border-b-2 border-primary py-2 text-primary">
+            <Text variant="BOLD_16">활동</Text>
+          </button>
+          <button className="border-b-2 border-secondary-300 py-2 text-secondary-300">
+            <Text variant="BOLD_16">키워드</Text>
+          </button>
         </div>
 
         <main className="px-3 pb-24 pt-2">
-          <div className="mb-3 flex h-7 items-center rounded-sm px-2 text-[10px] bg-secondary-100/30">
+          <div className="mb-3 flex h-7 items-center rounded-sm bg-secondary-100/30 px-2">
             <svg
               viewBox="0 0 24 24"
               className="mr-1.5 h-3.5 w-3.5 fill-none stroke-current stroke-2"
@@ -21,7 +26,7 @@ export default function Community() {
               <circle cx="11" cy="11" r="7" />
               <path d="m20 20-3.5-3.5" />
             </svg>
-            검색
+            <Text variant="LIGHT_14">검색</Text>
           </div>
 
           <section className="grid grid-cols-2 gap-2">

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -1,4 +1,7 @@
-const postPlaceholders = Array.from({ length: 12 })
+import CommunityPostGridItem from "../../components/community/CommunityPostGridItem";
+import type { ICommunityPostItme } from "../../types/community/post";
+
+const postPlaceholders = Array.from({ length: 12 }) as ICommunityPostItme[];
 
 export default function Community() {
   return (
@@ -21,11 +24,11 @@ export default function Community() {
             검색
           </div>
 
-          <div className="grid grid-cols-2 gap-2">
+          <section className="grid grid-cols-2 gap-2">
             {postPlaceholders.map((_, index) => (
-              <div key={index} className="h-[120px] rounded-[2px] bg-secondary-100" />
+              <CommunityPostGridItem key={index} item={postPlaceholders[index]} />
             ))}
-          </div>
+          </section>
         </main>
 
         <button className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-[11px] font-medium text-white shadow-sm">

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -2,7 +2,15 @@ import CommunityPostGridItem from "../../components/community/CommunityPostGridI
 import type { ICommunityPostItme } from "../../types/community/post";
 import Text from "../../components/common/Text";
 
-const postPlaceholders = Array.from({ length: 12 }) as ICommunityPostItme[];
+const postPlaceholders: ICommunityPostItme[] = Array.from({ length: 12 }, (_, index) => ({
+  boardId: index + 1,
+  themeComponentId: 1000 + index,
+  title: `테마 미리보기 ${index + 1}`,
+  previewImageUrl: "",
+  userEmail: "test@theme.com",
+  createdAt: "2026-03-04",
+  prefers: 0,
+}));
 
 export default function Community() {
   return (

--- a/src/pages/community/CommunityDetail.tsx
+++ b/src/pages/community/CommunityDetail.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import Text from "../../components/common/Text";
+
+export default function CommunityDetail() {
+  const { boardId } = useParams();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <main className="px-5 pt-8">
+      <section className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <div className="h-10 w-10 rounded-full bg-secondary-300" />
+          <div className="flex flex-col">
+            <Text variant="BOLD_15">강은성</Text>
+            <Text variant="REGULAR_10" className="text-secondary-400">
+              3월 25일
+            </Text>
+          </div>
+        </div>
+
+        <div className="relative flex items-center gap-2">
+          <button className="rounded-[5px] bg-primary px-4 py-1 text-white">
+            <Text variant="MEDIUM_12">팔로우</Text>
+          </button> 
+          <button
+            className="flex h-8 w-8 items-center justify-center rounded-full"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            aria-label="더보기 메뉴"
+          >
+            <span className="text-2xl leading-none">⋮</span>
+          </button>
+
+          {isMenuOpen && (
+            <div className="absolute right-0 top-10 z-20 w-[112px] overflow-hidden rounded-md border border-secondary-200 bg-white shadow-md">
+              <button className="w-full px-3 py-2 text-left hover:bg-secondary-50">
+                <Text variant="MEDIUM_12">테마 다운로드</Text>
+              </button>
+              <button className="w-full border-t border-secondary-100 px-3 py-2 text-left hover:bg-secondary-50">
+                <Text variant="MEDIUM_12">공유하기</Text>
+              </button>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="mt-3">
+        <div className="h-[330px] w-full rounded-[2px] bg-secondary-200" />
+        <div className="mt-3 flex items-center justify-center gap-1">
+          <span className="h-1.5 w-1.5 rounded-full bg-black" />
+          <span className="h-1.5 w-1.5 rounded-full bg-secondary-300" />
+          <span className="h-1.5 w-1.5 rounded-full bg-secondary-300" />
+        </div>
+      </section>
+
+      <section className="mt-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-5">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[18px] leading-none text-red-500">❤</span>
+              <Text variant="REGULAR_15">110</Text>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-[17px] leading-none">💬</span>
+              <Text variant="REGULAR_15">190</Text>
+            </div>
+          </div>
+          <span className="text-[18px] leading-none text-primary">🔖</span>
+        </div>
+
+        <div className="mt-2">
+          <Text variant="MEDIUM_14" className="mr-2">
+            강은성
+          </Text>
+          <Text variant="REGULAR_14">좋아요 댓글 후 저장해주세요 ^^ #{boardId}</Text>
+        </div>
+        <Text variant="REGULAR_14" className="mt-1 text-secondary-400">
+          4일 전
+        </Text>
+      </section>
+    </main>
+  );
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from "react-router-dom";
 import App from "../App.tsx";
 import Community from "../pages/community/Community.tsx";
+import CommunityDetail from "../pages/community/CommunityDetail.tsx";
 import MobileLayout from "../layouts/MobileLayout.tsx";
 
 export default function AppRoutes() {
@@ -9,6 +10,7 @@ export default function AppRoutes() {
       <Route element={<MobileLayout />}>
         <Route path="/" element={<App />} />
         <Route path="/community" element={<Community />} />
+        <Route path="/community/:boardId" element={<CommunityDetail />} />
       </Route>
     </Routes>
   );

--- a/src/types/community/post.ts
+++ b/src/types/community/post.ts
@@ -1,0 +1,14 @@
+/**
+ * 커뮤니티 관련 타입 정의 파일
+ */
+
+// 테마 커뮤니티 게시글 항목
+export interface ICommunityPostItme {
+  boardId: number;
+  themeComponentId: number;
+  title: string;
+  previewImageUrl: string;
+  userEmail: string;
+  createdAt: string;
+  prefers: number;
+}


### PR DESCRIPTION
## 작업내용
1. 테마 커뮤니티 게시글(목록 페이지) 항목 컴포넌트 분리
2. 헤더 및 상단 고정 컨텐츠 고정값 제거(header의 height에 따라 [활동/키워드]탭의 position이 바뀌어야 하는 현상 제거
3. variant 기반 Text 공용 컴포넌트 작성 (figma design 기반)
4. 테마 커뮤니티 상세 페이지 추가
<img width="352" height="711" alt="image" src="https://github.com/user-attachments/assets/ec939f07-3ed0-4788-901a-a713d99c31ce" />
