### PR TITLE
테마 커뮤니티 리팩터링 (issue: #17)

### DIFF
--- a/src/components/community/SearchBar.tsx
+++ b/src/components/community/SearchBar.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import SearchIcon from "../../components/icons/community/search.svg?react";
+
+export default function SearchBar() {
+  const [keyword, setKeyword] = useState("");
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if(!keyword.trim()) return; // 빈 값일 경우
+  }
+
+  return (
+    <form 
+      onSubmit={handleSearch}
+      className="flex w-full items-center gap-2 rounded-lg bg-gray-100 mt-1 mb-3 px-4 py-1.5 focus-within:ring-2 focus-within:ring-primary"
+    >
+      <SearchIcon className="h-5 w-5" />
+      
+      <input
+        type="text"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        placeholder="검색"
+        className="w-full bg-transparent text-sm outline-none placeholder:text-gray-400"
+      />
+      
+      {/* 화면에는 보이지 않지만 엔터 키 제출을 가능하게 하는 숨겨진 버튼 */}
+      <button type="submit" className="hidden">검색</button>
+    </form>
+  );
+}

--- a/src/components/community/index.ts
+++ b/src/components/community/index.ts
@@ -1,0 +1,5 @@
+export * from './tab';
+
+export { default as CommentModal } from './CommentModal';
+export { default as CommunityPostGridItem } from './CommunityPostGridItem';
+export { default as SearchBar } from './SearchBar';

--- a/src/components/community/tab/ActivityTab.tsx
+++ b/src/components/community/tab/ActivityTab.tsx
@@ -1,0 +1,32 @@
+import { CommunityPostGridItem, SearchBar } from "../../community";
+import Text from "../../common/Text";
+import type { ICommunityPostItem } from "../../../types/community/post";
+
+export default function ActivityTab() {
+  const postPlaceholders: ICommunityPostItem[] = Array.from({ length: 12 }, (_, index) => ({
+    boardId: index + 1,
+    themeComponentId: 1000 + index,
+    title: `테마 미리보기 ${index + 1}`,
+    previewImageUrl: "",
+    userEmail: "test@theme.com",
+    createdAt: "2026-03-04",
+    prefers: 0,
+  }));
+
+  return (
+    <>
+      <main className="px-3 pb-24 pt-2">
+        <SearchBar />
+        <section className="grid grid-cols-2 gap-2">
+          {postPlaceholders.map((item) => (
+            <CommunityPostGridItem key={item.boardId} item={item} />
+          ))}
+        </section>
+      </main>
+      <button className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-white shadow-sm">
+        <span className="mr-1 text-base leading-none">+</span>
+        <Text variant="REGULAR_14">글쓰기</Text>
+      </button>
+    </>
+  );
+}

--- a/src/components/community/tab/ActivityTab.tsx
+++ b/src/components/community/tab/ActivityTab.tsx
@@ -2,23 +2,23 @@ import { CommunityPostGridItem, SearchBar } from "../../community";
 import Text from "../../common/Text";
 import type { ICommunityPostItem } from "../../../types/community/post";
 
-export default function ActivityTab() {
-  const postPlaceholders: ICommunityPostItem[] = Array.from({ length: 12 }, (_, index) => ({
-    boardId: index + 1,
-    themeComponentId: 1000 + index,
-    title: `테마 미리보기 ${index + 1}`,
-    previewImageUrl: "",
-    userEmail: "test@theme.com",
-    createdAt: "2026-03-04",
-    prefers: 0,
-  }));
+const POST_PLACE_HOLDERS: ICommunityPostItem[] = Array.from({ length: 12 }, (_, index) => ({
+  boardId: index + 1,
+  themeComponentId: 1000 + index,
+  title: `테마 미리보기 ${index + 1}`,
+  previewImageUrl: "",
+  userEmail: "test@theme.com",
+  createdAt: "2026-03-04",
+  prefers: 0,
+}));
 
+export default function ActivityTab() {
   return (
     <>
       <main className="px-3 pb-24 pt-2">
         <SearchBar />
         <section className="grid grid-cols-2 gap-2">
-          {postPlaceholders.map((item) => (
+          {POST_PLACE_HOLDERS.map((item) => (
             <CommunityPostGridItem key={item.boardId} item={item} />
           ))}
         </section>

--- a/src/components/community/tab/KeywordTab.tsx
+++ b/src/components/community/tab/KeywordTab.tsx
@@ -1,0 +1,6 @@
+export default function KeywordTab() {
+  return (
+    <>
+    </>
+  );
+}

--- a/src/components/community/tab/TabMenu.tsx
+++ b/src/components/community/tab/TabMenu.tsx
@@ -1,0 +1,31 @@
+import Text from "../../common/Text";
+import type { ITab, TabId } from "../../../types/community/post";
+
+interface ITabMenuProps {
+  tabs: ITab[];
+  activeTab: TabId;
+  onTabChange: (id: TabId) => void;
+}
+
+export default function TabMenu({ tabs, activeTab, onTabChange }: ITabMenuProps) {
+  return(
+    <div className="sticky top-0 z-10 grid grid-cols-2 bg-white text-center">
+      {tabs.map((tab) => {
+        const isActive = activeTab === tab.id;
+
+        return (
+          <button 
+            key={tab.id} onClick={() => onTabChange(tab.id)}
+            className={`pt-4 pb-1 transition-colors ${isActive ? 'text-primary' : 'text-secondary-300'}`}
+          >
+            <span 
+              className={`border-b-2 pb-1 px-1 transition-all ${isActive ? 'border-primary' : 'border-transparent'}`}
+            >
+              <Text variant="BOLD_15">{tab.label}</Text>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/community/tab/index.ts
+++ b/src/components/community/tab/index.ts
@@ -1,0 +1,3 @@
+export { default as ActivityTab } from './ActivityTab';
+export { default as KeywordTab } from './KeywordTab';
+export { default as TabMenu } from './TabMenu';

--- a/src/components/icons/header/back-arrow.svg
+++ b/src/components/icons/header/back-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="18" viewBox="0 0 11 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.41418 17L1.41418 9L9.41419 1" stroke="black" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/layouts/MobileHeader.tsx
+++ b/src/layouts/MobileHeader.tsx
@@ -11,26 +11,24 @@ interface IMobileHeaderProps {
 export default function MobileHeader({ title, showBackArrow }: IMobileHeaderProps) {
   const navigate = useNavigate();
   return (
-    <header className="relative shrink-0 bg-white px-4 pt-10">
-      <div className="flex items-center justify-center gap-3">
-        {/* 왼쪽 영역: 뒤로가기 버튼 */}
-        <div className="absolute left-4">
-          {showBackArrow ? (
-            <button onClick={() => navigate(-1)} className="p-1">
-              <BackArrowIcon />
-            </button>
-          ) : (null)}
-        </div>
-
-        {/* 중앙 영역: 로고+제목 */}
-        <div className="flex items-center gap-2">
-          <HeaderIcon className="h-5 w-6" />
-          <Text variant="SEMIBOLD_15">{title}</Text>
-        </div>
-
-        {/* 오른쪽 영역(현재 비어있음) */}
-        <div className="absolute right-4 w-6" />
+    <header className="relative flex shrink-0 items-center justify-center bg-white px-4 pt-10">
+      {/* 왼쪽 영역: 뒤로가기 버튼 */}
+      <div className="absolute left-4">
+        {showBackArrow && (
+          <button onClick={() => navigate(-1)} className="p-1">
+            <BackArrowIcon />
+          </button>
+        )}
       </div>
+
+      {/* 중앙 영역: 로고+제목 */}
+      <div className="flex items-center gap-2">
+        <HeaderIcon className="h-5 w-6" />
+        <Text variant="SEMIBOLD_15">{title}</Text>
+      </div>
+
+      {/* 오른쪽 영역(현재 비어있음) */}
+      <div className="absolute right-4 w-6" />
     </header>
   )
 }

--- a/src/layouts/MobileHeader.tsx
+++ b/src/layouts/MobileHeader.tsx
@@ -1,16 +1,35 @@
 import HeaderIcon from "../components/icons/header/header.svg?react";
+import BackArrowIcon from "../components/icons/header/back-arrow.svg?react";
 import Text from "../components/common/Text";
+import { useNavigate } from "react-router-dom";
 
 interface IMobileHeaderProps {
-  title: string
+  title: string;
+  showBackArrow?: boolean;
 }
 
-export default function MobileHeader({ title }: IMobileHeaderProps) {
+export default function MobileHeader({ title, showBackArrow }: IMobileHeaderProps) {
+  const navigate = useNavigate();
   return (
-    <header className="shrink-0 bg-white px-4 pt-10">
+    <header className="relative shrink-0 bg-white px-4 pt-10">
       <div className="flex items-center justify-center gap-3">
-        <HeaderIcon className="h-5 w-6" />
-        <Text variant="SEMIBOLD_15">{title}</Text>
+        {/* 왼쪽 영역: 뒤로가기 버튼 */}
+        <div className="absolute left-4">
+          {showBackArrow ? (
+            <button onClick={() => navigate(-1)} className="p-1">
+              <BackArrowIcon />
+            </button>
+          ) : (null)}
+        </div>
+
+        {/* 중앙 영역: 로고+제목 */}
+        <div className="flex items-center gap-2">
+          <HeaderIcon className="h-5 w-6" />
+          <Text variant="SEMIBOLD_15">{title}</Text>
+        </div>
+
+        {/* 오른쪽 영역(현재 비어있음) */}
+        <div className="absolute right-4 w-6" />
       </div>
     </header>
   )

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -9,10 +9,14 @@ export default function MobileLayout() {
   const hasHeader: boolean = isHome || isCommunity
   const headerTitle: string = isCommunity ? "테마 커뮤니티" : "고정 헤더"
 
+  // 뒤로가기 버튼을 보여주어야 하는 경로인지 판별
+  // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/6'의 경우 2로 봄)
+  const showBackArrow: boolean = pathname.split('/').length >= 3;
+
   return (
     <div className="flex min-h-screen items-start justify-center bg-white py-4">
       <div className="relative flex h-[700px] w-[340px] flex-col overflow-hidden border border-secondary-200">
-        {hasHeader && <MobileHeader title={headerTitle} />}
+        {hasHeader && <MobileHeader title={headerTitle} showBackArrow={showBackArrow} />}
 
         <div className="scrollbar-hidden flex-1 overflow-y-auto pb-16">
           <Outlet />

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -11,7 +11,8 @@ export default function MobileLayout() {
 
   // 뒤로가기 버튼을 보여주어야 하는 경로인지 판별
   // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/6'의 경우 2로 봄)
-  const showBackArrow: boolean = pathname.split('/').length >= 3;
+  // 경로의 끝에 /가 올 경우 정확하게 처리하지 못할 수 있어 filter(Boolean)을 사용하여 빈 문자열을 제거
+  const showBackArrow: boolean = pathname.split('/').filter(Boolean).length >= 2;
 
   return (
     <div className="flex min-h-screen items-start justify-center bg-white py-4">

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -7,16 +7,15 @@ const tabs: ITab[] = [
   { id: 'activity', label: '활동' },
   { id: 'keyword', label: '키워드' },
 ];
-
-export default function Community() {
-  // 탭 메뉴 상태값, 초기값은 activity: 활동
-  const [activeTab, setActiveTab] = useState<TabId>('activity');
-
-  // 확장 가능성을 염두에 두어 객체 매핑 구조로 설계
+// 확장 가능성을 염두에 두어 객체 매핑 구조로 설계
   const TAB_COMPONENTS: Record<TabId, React.ReactNode> = {
     activity: <ActivityTab />,
     keyword: <KeywordTab />,
   }
+
+export default function Community() {
+  // 탭 메뉴 상태값, 초기값은 activity: 활동
+  const [activeTab, setActiveTab] = useState<TabId>('activity');
 
   return (
     <div>

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -104,14 +104,16 @@ function KeywordTab() {
   );
 }
 
+// 컴포넌트 외부로 이동 (불필요한 재생성 방지)
+const tabs: ITab[] = [
+  { id: 'activity', label: '활동' },
+  { id: 'keyword', label: '키워드' },
+];
+
 export default function Community() {
   // 탭 메뉴 상태값, 초기값은 activity: 활동
   const [activeTab, setActiveTab] = useState<TabId>('activity');
   // 탭 메뉴 데이터 (확장 가능성을 염두에 두어 배열로 관리)
-  const tabs: ITab[] = [
-    { id: 'activity', label: '활동' },
-    { id: 'keyword', label: '키워드' },
-  ];
 
   const TAB_COMPONENTS: Record<TabId, React.ReactNode> = {
     activity: <ActivityTab />,

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -4,15 +4,16 @@ import type { ICommunityPostItem } from "../../types/community/post";
 import Text from "../../components/common/Text";
 import SearchIcon from "../../components/icons/community/search.svg?react";
 
-const postPlaceholders: ICommunityPostItem[] = Array.from({ length: 12 }, (_, index) => ({
-  boardId: index + 1,
-  themeComponentId: 1000 + index,
-  title: `테마 미리보기 ${index + 1}`,
-  previewImageUrl: "",
-  userEmail: "test@theme.com",
-  createdAt: "2026-03-04",
-  prefers: 0,
-}));
+type TabId = 'activity' | 'keyword';
+interface ITab {
+  id: TabId
+  label: string;
+}
+interface ITabMenuProps {
+  tabs: ITab[];
+  activeTab: TabId;
+  onTabChange: (id: TabId) => void;
+}
 
 function SearchBar() {
   const [keyword, setKeyword] = useState("");
@@ -44,32 +45,82 @@ function SearchBar() {
   );
 }
 
-export default function Community() {
+function TabMenu({ tabs, activeTab, onTabChange }: ITabMenuProps) {
+  return(
+    <div className="sticky top-0 z-10 grid grid-cols-2 bg-white text-center">
+      {tabs.map((tab) => {
+        const isActive = activeTab === tab.id;
+
+        return (
+          <button 
+            key={tab.id} onClick={() => onTabChange(tab.id)}
+            className={`pt-4 pb-1 transition-colors ${isActive ? 'text-primary' : 'text-secondary-300'}`}
+          >
+            <span 
+              className={`border-b-2 pb-1 px-1 transition-all ${isActive ? 'border-primary' : 'border-transparent'}`}
+            >
+              <Text variant="BOLD_15">{tab.label}</Text>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ActivityTab() {
+  const postPlaceholders: ICommunityPostItem[] = Array.from({ length: 12 }, (_, index) => ({
+    boardId: index + 1,
+    themeComponentId: 1000 + index,
+    title: `테마 미리보기 ${index + 1}`,
+    previewImageUrl: "",
+    userEmail: "test@theme.com",
+    createdAt: "2026-03-04",
+    prefers: 0,
+  }));
+
   return (
     <>
-        <div className="sticky top-0 z-10 grid grid-cols-2 bg-white text-center text-[14px] font-bold">
-          <button className="border-b-2 border-primary py-2 text-primary">
-            <Text variant="BOLD_16">활동</Text>
-          </button>
-          <button className="border-b-2 border-secondary-300 py-2 text-secondary-300">
-            <Text variant="BOLD_16">키워드</Text>
-          </button>
-        </div>
+      <main className="px-3 pb-24 pt-2">
+        <SearchBar />
+        <section className="grid grid-cols-2 gap-2">
+          {postPlaceholders.map((item) => (
+            <CommunityPostGridItem key={item.boardId} item={item} />
+          ))}
+        </section>
+      </main>
+      <button className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-white shadow-sm">
+        <span className="mr-1 text-base leading-none">+</span>
+        <Text variant="REGULAR_14">글쓰기</Text>
+      </button>
+    </>
+  );
+}
 
-        <main className="px-3 pb-24 pt-2">
-          <SearchBar />
+function KeywordTab() {
+  return (
+    <>
+    </>
+  );
+}
 
-          <section className="grid grid-cols-2 gap-2">
-            {postPlaceholders.map((item) => (
-              <CommunityPostGridItem key={item.boardId} item={item} />
-            ))}
-          </section>
-        </main>
+export default function Community() {
+  // 탭 메뉴 상태값, 초기값은 activity: 활동
+  const [activeTab, setActiveTab] = useState<TabId>('activity');
+  // 탭 메뉴 데이터 (확장 가능성을 염두에 두어 배열로 관리)
+  const tabs: ITab[] = [
+    { id: 'activity', label: '활동' },
+    { id: 'keyword', label: '키워드' },
+  ];
 
-        <button className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-white shadow-sm">
-          <span className="mr-1 text-base leading-none">+</span>
-          <Text variant="REGULAR_14">글쓰기</Text>
-        </button>
+  return (
+    <>
+      <TabMenu tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
+      {activeTab === 'activity' ? (
+          <ActivityTab /> // 활동 컴포넌트
+        ) : (
+          <KeywordTab />  // 키워드 컴포넌트
+      )}
     </>
   )
 }

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -1,108 +1,6 @@
 import { useState } from 'react';
-import CommunityPostGridItem from "../../components/community/CommunityPostGridItem";
-import type { ICommunityPostItem } from "../../types/community/post";
-import Text from "../../components/common/Text";
-import SearchIcon from "../../components/icons/community/search.svg?react";
-
-type TabId = 'activity' | 'keyword';
-interface ITab {
-  id: TabId
-  label: string;
-}
-interface ITabMenuProps {
-  tabs: ITab[];
-  activeTab: TabId;
-  onTabChange: (id: TabId) => void;
-}
-
-function SearchBar() {
-  const [keyword, setKeyword] = useState("");
-
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if(!keyword.trim()) return; // 빈 값일 경우
-  }
-
-  return (
-    <form 
-      onSubmit={handleSearch}
-      className="flex w-full items-center gap-2 rounded-lg bg-gray-100 mt-1 mb-3 px-4 py-1.5 focus-within:ring-2 focus-within:ring-primary"
-    >
-      <SearchIcon className="h-5 w-5" />
-      
-      <input
-        type="text"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-        placeholder="검색"
-        className="w-full bg-transparent text-sm outline-none placeholder:text-gray-400"
-      />
-      
-      {/* 화면에는 보이지 않지만 엔터 키 제출을 가능하게 하는 숨겨진 버튼 */}
-      <button type="submit" className="hidden">검색</button>
-    </form>
-  );
-}
-
-function TabMenu({ tabs, activeTab, onTabChange }: ITabMenuProps) {
-  return(
-    <div className="sticky top-0 z-10 grid grid-cols-2 bg-white text-center">
-      {tabs.map((tab) => {
-        const isActive = activeTab === tab.id;
-
-        return (
-          <button 
-            key={tab.id} onClick={() => onTabChange(tab.id)}
-            className={`pt-4 pb-1 transition-colors ${isActive ? 'text-primary' : 'text-secondary-300'}`}
-          >
-            <span 
-              className={`border-b-2 pb-1 px-1 transition-all ${isActive ? 'border-primary' : 'border-transparent'}`}
-            >
-              <Text variant="BOLD_15">{tab.label}</Text>
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function ActivityTab() {
-  const postPlaceholders: ICommunityPostItem[] = Array.from({ length: 12 }, (_, index) => ({
-    boardId: index + 1,
-    themeComponentId: 1000 + index,
-    title: `테마 미리보기 ${index + 1}`,
-    previewImageUrl: "",
-    userEmail: "test@theme.com",
-    createdAt: "2026-03-04",
-    prefers: 0,
-  }));
-
-  return (
-    <>
-      <main className="px-3 pb-24 pt-2">
-        <SearchBar />
-        <section className="grid grid-cols-2 gap-2">
-          {postPlaceholders.map((item) => (
-            <CommunityPostGridItem key={item.boardId} item={item} />
-          ))}
-        </section>
-      </main>
-      <button className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-white shadow-sm">
-        <span className="mr-1 text-base leading-none">+</span>
-        <Text variant="REGULAR_14">글쓰기</Text>
-      </button>
-    </>
-  );
-}
-
-function KeywordTab() {
-  return (
-    <>
-    </>
-  );
-}
+import { ActivityTab, KeywordTab, TabMenu } from "../../components/community";
+import type { ITab, TabId } from "../../types/community/post";
 
 // 컴포넌트 외부로 이동 (불필요한 재생성 방지)
 const tabs: ITab[] = [
@@ -113,17 +11,19 @@ const tabs: ITab[] = [
 export default function Community() {
   // 탭 메뉴 상태값, 초기값은 activity: 활동
   const [activeTab, setActiveTab] = useState<TabId>('activity');
-  // 탭 메뉴 데이터 (확장 가능성을 염두에 두어 배열로 관리)
 
+  // 확장 가능성을 염두에 두어 객체 매핑 구조로 설계
   const TAB_COMPONENTS: Record<TabId, React.ReactNode> = {
     activity: <ActivityTab />,
     keyword: <KeywordTab />,
   }
 
   return (
-    <>
+    <div>
       <TabMenu tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
-      {TAB_COMPONENTS[activeTab]}
-    </>
+      <div className="flex-1">
+        {TAB_COMPONENTS[activeTab]}
+      </div>
+    </div>
   )
 }

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -113,14 +113,15 @@ export default function Community() {
     { id: 'keyword', label: '키워드' },
   ];
 
+  const TAB_COMPONENTS: Record<TabId, React.ReactNode> = {
+    activity: <ActivityTab />,
+    keyword: <KeywordTab />,
+  }
+
   return (
     <>
       <TabMenu tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
-      {activeTab === 'activity' ? (
-          <ActivityTab /> // 활동 컴포넌트
-        ) : (
-          <KeywordTab />  // 키워드 컴포넌트
-      )}
+      {TAB_COMPONENTS[activeTab]}
     </>
   )
 }

--- a/src/types/community/post.ts
+++ b/src/types/community/post.ts
@@ -20,3 +20,9 @@ export interface IComment {
   date: string;
   isLiked: boolean;
 }
+
+export type TabId = 'activity' | 'keyword';
+export interface ITab {
+  id: TabId
+  label: string;
+}


### PR DESCRIPTION
1. 탭메뉴 및 활동 탭 페이지, 키워드 탭 페이지 분리
2. 탭메뉴 렌더링 시 기존 삼항연산에서 객체 매핑 구조로 변경
3. 커뮤니티 페이지의 각 컴포넌트 요소들 파일 분리
4. 뒤로가기 버튼 추가 (path의 depth가 2이상인 경우 --> '/community/2')

<img width="402" height="739" alt="image" src="https://github.com/user-attachments/assets/0063e66e-1d08-4b0d-b861-4867bc7e2ff3" />
