### PR TITLE
feat: 게시글 북마크 API 연동 (#53)

### DIFF
--- a/src/components/community/BoardDetailCard.tsx
+++ b/src/components/community/BoardDetailCard.tsx
@@ -7,6 +7,7 @@ import Text from '../common/Text';
 import { useOutsideClick } from '../../services/hooks/common/useOutsideClick';
 import { useCommentActions } from '../../services/hooks/common/useCommentActions';
 import { usePrefer } from '../../services/hooks/common/usePrefer';
+import { useBookmark } from '../../services/hooks/common/useBookmark';
 import { useAuthStore } from '../../stores/authStore';
 import ImageSlider from '../common/ImageSlider';
 import CommentModal from './CommentModal';
@@ -41,7 +42,11 @@ export default function BoardDetailCard({
   const userEmail = useAuthStore((state) => state.userEmail);
   const isMyBoard = userEmail === board.userEmail;
 
-  const [isBookmarked, setIsBookmarked] = useState(board.isBookmarked);
+  const { isBookmarked, toggleBookmark, isPending: isBookmarkPending } = useBookmark(
+    board.boardId,
+    board.isBookmarked,
+    preferQueryKey,
+  );
   const { isPreferred, prefers, togglePrefer, isPending } = usePrefer(
     board.boardId,
     board.prefers,
@@ -172,7 +177,7 @@ export default function BoardDetailCard({
               <Text variant="REGULAR_15">{board.comments}</Text>
             </div>
           </div>
-          <button onClick={() => setIsBookmarked((prev) => !prev)} aria-label="북마크">
+          <button onClick={toggleBookmark} disabled={isBookmarkPending} aria-label="북마크">
             <BookmarkIcon
               width={12}
               height={17}

--- a/src/services/api/BoardInteractionService.ts
+++ b/src/services/api/BoardInteractionService.ts
@@ -31,4 +31,14 @@ export const BoardInteractionService = {
     apiClient
       .put<ICommentRaw>(`/api/posts/comments/${commentId}`, { content })
       .then((res) => res.data),
+
+  bookmarkPost: (postId: number) =>
+    apiClient
+      .put(`/api/bookmarks/posts/${postId}`)
+      .then((res) => res.data),
+
+  unbookmarkPost: (postId: number) =>
+    apiClient
+      .delete(`/api/bookmarks/posts/${postId}`)
+      .then((res) => res.data),
 };

--- a/src/services/hooks/common/useBookmark.ts
+++ b/src/services/hooks/common/useBookmark.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { usePostMutation, useDeleteMutation } from '../../api/useApi';
+import { BoardInteractionService } from '../../api/BoardInteractionService';
+
+type IBookmarkSnapshot = { snapshot: Record<string, unknown> | undefined };
+
+export function useBookmark(
+  postId: number,
+  initialIsBookmarked: boolean = false,
+  queryKey?: unknown[],
+) {
+  const queryClient = useQueryClient();
+  const [isBookmarked, setIsBookmarked] = useState(initialIsBookmarked);
+
+  useEffect(() => {
+    setIsBookmarked(initialIsBookmarked);
+  }, [initialIsBookmarked]);
+
+  const { mutate: bookmark, isPending: isBookmarkPending } = usePostMutation<unknown, number>(
+    (id) => BoardInteractionService.bookmarkPost(id),
+    {
+      onMutate: async () => {
+        if (!queryKey) return undefined;
+        await queryClient.cancelQueries({ queryKey });
+        const snapshot = queryClient.getQueryData<Record<string, unknown>>(queryKey);
+        queryClient.setQueryData(queryKey, (old: Record<string, unknown> | undefined) =>
+          old ? { ...old, isBookmarked: true } : old,
+        );
+        return { snapshot } as IBookmarkSnapshot;
+      },
+      onError: (_err, _vars, context) => {
+        const ctx = context as IBookmarkSnapshot | undefined;
+        if (queryKey && ctx?.snapshot !== undefined) {
+          queryClient.setQueryData(queryKey, ctx.snapshot);
+        }
+        setIsBookmarked(false);
+      },
+      onSettled: () => {
+        if (queryKey) queryClient.invalidateQueries({ queryKey });
+      },
+    },
+  );
+
+  const { mutate: unbookmark, isPending: isUnbookmarkPending } = useDeleteMutation<unknown, number>(
+    (id) => BoardInteractionService.unbookmarkPost(id),
+    {
+      onMutate: async () => {
+        if (!queryKey) return undefined;
+        await queryClient.cancelQueries({ queryKey });
+        const snapshot = queryClient.getQueryData<Record<string, unknown>>(queryKey);
+        queryClient.setQueryData(queryKey, (old: Record<string, unknown> | undefined) =>
+          old ? { ...old, isBookmarked: false } : old,
+        );
+        return { snapshot } as IBookmarkSnapshot;
+      },
+      onError: (_err, _vars, context) => {
+        const ctx = context as IBookmarkSnapshot | undefined;
+        if (queryKey && ctx?.snapshot !== undefined) {
+          queryClient.setQueryData(queryKey, ctx.snapshot);
+        }
+        setIsBookmarked(true);
+      },
+      onSettled: () => {
+        if (queryKey) queryClient.invalidateQueries({ queryKey });
+      },
+    },
+  );
+
+  const toggleBookmark = () => {
+    if (isBookmarked) {
+      setIsBookmarked(false);
+      unbookmark(postId);
+    } else {
+      setIsBookmarked(true);
+      bookmark(postId);
+    }
+  };
+
+  return { isBookmarked, toggleBookmark, isPending: isBookmarkPending || isUnbookmarkPending };
+}


### PR DESCRIPTION
- BoardInteractionService에 bookmarkPost(PUT), unbookmarkPost(DELETE) 메서드 추가
- useBookmark 훅 생성 (낙관적 업데이트 + 실패 시 롤백)
- BoardDetailCard 북마크 버튼을 로컬 상태에서 useBookmark 훅으로 교체