### PR TITLE
refactor: 마이페이지 스크롤 UX 개선 및 레이아웃 수정 (#56)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md
+
+이 파일은 이 저장소에서 AI 코딩 에이전트가 작업할 때 참고할 프로젝트 가이드입니다.
+
+## 프로젝트 개요
+
+카카오톡 테마를 선택하고 커스터마이징하는 React 웹 프로젝트입니다.
+
+## 주요 명령어
+
+```bash
+npm run dev      # 개발 서버 실행
+npm run build    # TypeScript 체크 + Vite 빌드
+npm run lint     # ESLint 실행
+npm run preview  # 프로덕션 빌드 프리뷰
+```
+
+## 기술 스택
+
+- 빌드: Vite 7 + SWC
+- 프레임워크: React 19 + TypeScript strict mode
+- 스타일링: TailwindCSS
+- 상태 관리: Zustand
+- 서버 상태: TanStack React Query
+- 라우팅: React Router DOM v7
+- 폼: React Hook Form
+- HTTP: Axios
+- 린트: ESLint 9 flat config
+
+## 작업 방식
+
+- 기존 코드 구조와 패턴을 먼저 확인한 뒤 작업합니다.
+- 원인, 해결 방안, 선택 이유가 필요한 작업은 구현 전에 간단히 설명합니다.
+- 새로운 기능이나 페이지를 개발할 때는 먼저 작업 계획을 세웁니다.
+- 사용자가 이미 수정한 변경사항은 되돌리지 않습니다.
+- 변경 범위는 요청과 직접 관련된 파일로 좁게 유지합니다.
+- 작업 후 가능한 경우 `npm run lint` 또는 `npm run build`로 검증합니다.
+
+## 아키텍처 원칙
+
+- Screen 컴포넌트는 데이터 페칭과 상태 관리만 담당하고, UI 렌더링은 하위 컴포넌트에 위임합니다.
+- 재사용 가능한 UI 요소는 공통 컴포넌트로 분리합니다.
+- 비즈니스 로직은 Custom Hook으로 분리하여 컴포넌트를 단순하게 유지합니다.
+- 단일 컴포넌트는 200줄 이내를 권장하며, 초과 시 분리를 검토합니다.
+- JSX 반환부는 100줄 이내를 권장합니다.
+
+## 폴더 구조
+
+- `src/components`: UI 구성용 컴포넌트 모음
+- `src/components/common`: 자주 사용되는 공통 디자인 컴포넌트
+- `src/components/icons`: 아이콘 컴포넌트
+- `src/components/ui`: 외부에서 제공되는 디자인 컴포넌트
+- `src/pages`: 라우터에 연결되는 페이지 컴포넌트
+- `src/routes`: React Router DOM 기반 라우팅 파일
+- `src/services`: API 호출, 데이터 관리, 훅 관리
+- `src/utils`: 공통 유틸 함수, `clsx`, providers 등
+
+라우팅 예시는 `AppRoutes.tsx`, `ProtectedRoutes.tsx`를 참고합니다.
+
+## 네이밍 컨벤션
+
+- 컴포넌트 파일: PascalCase
+- 폴더 이름: kebab-case
+- props 타입: PascalCase
+- API / Service 이름: PascalCase
+- React Query 관련 이름: PascalCase
+- 상태 변수: camelCase
+- 인터페이스: PascalCase, 앞에 `I` 접두사 사용
+- 상수: SCREAMING_SNAKE_CASE
+- boolean 변수: `is` 또는 `has` 접두사 사용
+- 일반 커스텀 훅: `use*` 형태의 camelCase
+
+## 스타일 규칙
+
+- TailwindCSS만 사용합니다.
+- 불필요한 커스텀 CSS는 추가하지 않습니다.
+- 기존 공통 컴포넌트와 디자인 패턴을 우선 사용합니다.
+
+## 타입 규칙
+
+- interface는 관련 `types.ts` 파일로 묶어서 관리합니다.
+- 기존 타입 정의 위치가 있다면 새 타입도 같은 책임 범위에 추가합니다.
+
+## Git Workflow
+
+- `main`: 기본 셋팅 및 icons constant 변수만 관리
+- `develop`: 개발 통합 브랜치

--- a/src/components/community/BoardDetailCard.tsx
+++ b/src/components/community/BoardDetailCard.tsx
@@ -29,6 +29,7 @@ interface IBoardDetailCardProps {
   portalContainer?: Element | null;
   moreMenuItems?: IMoreMenuItem[];
   removeOnUnbookmark?: boolean;
+  allowBookmarkForMyBoard?: boolean;
 }
 
 export default function BoardDetailCard({
@@ -41,6 +42,7 @@ export default function BoardDetailCard({
   portalContainer,
   moreMenuItems,
   removeOnUnbookmark,
+  allowBookmarkForMyBoard,
 }: IBoardDetailCardProps) {
   const navigate = useNavigate();
   const userEmail = useAuthStore((state) => state.userEmail);
@@ -95,7 +97,7 @@ export default function BoardDetailCard({
   };
 
   const handleBookmark = () => {
-    if (isMyBoard) return;
+    if (isMyBoard && !allowBookmarkForMyBoard) return;
     toggleBookmark();
   };
 
@@ -214,7 +216,7 @@ export default function BoardDetailCard({
           </div>
           <button
             onClick={handleBookmark}
-            disabled={isBookmarkPending || isMyBoard}
+            disabled={isBookmarkPending || (isMyBoard && !allowBookmarkForMyBoard)}
             aria-label="북마크"
           >
             <BookmarkIcon

--- a/src/components/community/CommentModal.tsx
+++ b/src/components/community/CommentModal.tsx
@@ -5,12 +5,94 @@ import { useAuthStore } from "../../stores/authStore";
 import { useOutsideClick } from "../../services/hooks/common/useOutsideClick";
 import { useCreateComment } from "../../services/hooks/common/useCreateComment";
 import { useComments } from "../../services/hooks/common/useComments";
+import { useCommentLike } from "../../services/hooks/common/useCommentLike";
 import type { ICommentRaw } from "../../types/community/theme";
 
 interface ICommentModalProps {
   boardId: number;
   onRequestDelete: (commentId: number) => void;
   onRequestEdit: (commentId: number, content: string) => void;
+}
+
+interface ICommentItemProps {
+  boardId: number;
+  comment: ICommentRaw;
+  userEmail?: string | null;
+  editingId: number | null;
+  editText: string;
+  editInputRef: React.RefObject<HTMLDivElement | null>;
+  onEditTextChange: (value: string) => void;
+  onEditKeyDown: (e: React.KeyboardEvent, comment: ICommentRaw) => void;
+  onRequestDelete: (commentId: number) => void;
+  onStartEdit: (comment: ICommentRaw) => void;
+}
+
+function CommentItem({
+  boardId,
+  comment,
+  userEmail,
+  editingId,
+  editText,
+  editInputRef,
+  onEditTextChange,
+  onEditKeyDown,
+  onRequestDelete,
+  onStartEdit,
+}: ICommentItemProps) {
+  const { isLiked, likes, toggleCommentLike, isPending } = useCommentLike(boardId, comment);
+  const isMyComment = userEmail === comment.userEmail;
+
+  return (
+    <div className="flex items-start justify-between">
+      <div className="flex gap-3">
+        <div className="h-10 w-10 rounded-full bg-gray-300 flex-shrink-0" />
+        <div>
+          <Text variant="BOLD_12">{comment.userName ?? comment.userEmail}</Text>
+          <div className="mt-[-5px]">
+            {editingId === comment.commentId ? (
+              <div ref={editInputRef}>
+                <input
+                  autoFocus
+                  type="text"
+                  value={editText}
+                  onChange={(e) => onEditTextChange(e.target.value)}
+                  onKeyDown={(e) => onEditKeyDown(e, comment)}
+                  className="rounded border border-gray-300 px-2 py-1 text-xs outline-none focus:border-blue-400"
+                />
+              </div>
+            ) : (
+              <Text variant="MEDIUM_12">{comment.content}</Text>
+            )}
+          </div>
+          {isMyComment && (
+            <div className="flex gap-2">
+              <button
+                className="text-xs text-secondary-300 hover:underline"
+                onClick={() => onRequestDelete(comment.commentId)}
+              >
+                삭제
+              </button>
+              <button
+                className="text-xs text-secondary-300 hover:underline"
+                onClick={() => onStartEdit(comment)}
+              >
+                수정
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+      <button
+        className="flex min-w-9 flex-col items-center text-secondary-300 disabled:cursor-not-allowed"
+        onClick={toggleCommentLike}
+        disabled={isPending || isMyComment}
+        aria-label={isLiked ? "댓글 좋아요 취소" : "댓글 좋아요"}
+      >
+        <HeartIcon className={`h-5 w-5 ${isLiked ? "text-red-500" : "text-secondary-300"}`} />
+        <span className="mt-1 text-xs text-secondary-300">{likes.toLocaleString()}</span>
+      </button>
+    </div>
+  );
 }
 
 export default function CommentModal({ boardId, onRequestDelete, onRequestEdit }: ICommentModalProps) {
@@ -54,49 +136,22 @@ export default function CommentModal({ boardId, onRequestDelete, onRequestEdit }
       {/* 댓글 리스트 */}
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {comments.map((comment) => (
-          <div key={comment.commentId} className="flex items-start justify-between">
-            <div className="flex gap-3">
-              <div className="h-10 w-10 rounded-full bg-gray-300 flex-shrink-0" />
-              <div>
-                <Text variant="BOLD_12">{comment.userEmail}</Text>
-                <div className="mt-[-5px]">
-                  {editingId === comment.commentId ? (
-                    <div ref={editInputRef}>
-                      <input
-                        autoFocus
-                        type="text"
-                        value={editText}
-                        onChange={(e) => setEditText(e.target.value)}
-                        onKeyDown={(e) => handleEditKeyDown(e, comment)}
-                        className="rounded border border-gray-300 px-2 py-1 text-xs outline-none focus:border-blue-400"
-                      />
-                    </div>
-                  ) : (
-                    <Text variant="MEDIUM_12">{comment.content}</Text>
-                  )}
-                </div>
-                {userEmail === comment.userEmail && (
-                  <div className="flex gap-2">
-                    <button
-                      className="text-xs text-secondary-300 hover:underline"
-                      onClick={() => onRequestDelete(comment.commentId)}
-                    >
-                      삭제
-                    </button>
-                    <button
-                      className="text-xs text-secondary-300 hover:underline"
-                      onClick={() => { setEditingId(comment.commentId); setEditText(comment.content); }}
-                    >
-                      수정
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-            <button className="text-gray-300">
-              <HeartIcon className="h-5 w-5 fill-currentColor" />
-            </button>
-          </div>
+          <CommentItem
+            key={comment.commentId}
+            boardId={boardId}
+            comment={comment}
+            userEmail={userEmail}
+            editingId={editingId}
+            editText={editText}
+            editInputRef={editInputRef}
+            onEditTextChange={setEditText}
+            onEditKeyDown={handleEditKeyDown}
+            onRequestDelete={onRequestDelete}
+            onStartEdit={(targetComment) => {
+              setEditingId(targetComment.commentId);
+              setEditText(targetComment.content);
+            }}
+          />
         ))}
       </div>
 

--- a/src/components/mypage/ActivityTab.tsx
+++ b/src/components/mypage/ActivityTab.tsx
@@ -1,55 +1,70 @@
+import { useEffect } from 'react';
 import Text from '../common/Text';
 import MyActivityCard from './MyActivityCard';
 import { useMyUploadPosts } from '../../services/hooks/user/useMyUploadPosts';
-import { useIntersectionObserver } from '../../services/hooks/common/useIntersectionObserver';
+import { useVerticalSwipe } from '../../services/hooks/common/useVerticalSwipe';
+
+const TRANSITION_DURATION = 700;
+const PREFETCH_THRESHOLD = 3;
 
 export default function ActivityTab() {
   const { posts, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyUploadPosts();
 
-  const sentinelRef = useIntersectionObserver(() => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  });
+  const { currentIndex, containerRef, handleTouchStart, handleTouchEnd } =
+    useVerticalSwipe(posts.length, TRANSITION_DURATION);
 
-  if (isLoading) {
-    return (
-      <div className="flex h-40 items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="flex h-40 items-center justify-center">
-        <Text variant="REGULAR_14" className="text-red-400">
-          게시글을 불러올 수 없습니다.
-        </Text>
-      </div>
-    );
-  }
-
-  if (posts.length === 0) {
-    return (
-      <div className="flex h-40 items-center justify-center">
-        <Text variant="REGULAR_14" className="text-secondary-300">
-          아직 활동이 없습니다.
-        </Text>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (
+      posts.length > 0 &&
+      hasNextPage &&
+      !isFetchingNextPage &&
+      currentIndex >= posts.length - PREFETCH_THRESHOLD
+    ) {
+      fetchNextPage();
+    }
+  }, [currentIndex, posts.length, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <div>
-      {posts.map((post) => (
-        <MyActivityCard key={post.boardId} post={post} />
-      ))}
-      <div ref={sentinelRef} className="h-1" />
-      {isFetchingNextPage && (
-        <div className="flex items-center justify-center py-4">
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    <div
+      ref={containerRef}
+      className="relative h-full overflow-hidden"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      {isLoading && (
+        <div className="flex h-full items-center justify-center">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
         </div>
       )}
+      {isError && (
+        <div className="flex h-full items-center justify-center">
+          <Text variant="REGULAR_14" className="text-red-400">
+            게시글을 불러올 수 없습니다.
+          </Text>
+        </div>
+      )}
+      {!isLoading && !isError && posts.length === 0 && (
+        <div className="flex h-full items-center justify-center">
+          <Text variant="REGULAR_14" className="text-secondary-300">
+            아직 활동이 없습니다.
+          </Text>
+        </div>
+      )}
+      {!isLoading &&
+        !isError &&
+        posts.map((post, idx) => (
+          <div
+            key={post.boardId}
+            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
+            style={{
+              transform: `translateY(${(idx - currentIndex) * 100}%)`,
+              transitionDuration: `${TRANSITION_DURATION}ms`,
+            }}
+          >
+            <MyActivityCard post={post} />
+          </div>
+        ))}
     </div>
   );
 }

--- a/src/components/mypage/ActivityTab.tsx
+++ b/src/components/mypage/ActivityTab.tsx
@@ -1,51 +1,34 @@
-import { useEffect } from 'react';
 import Text from '../common/Text';
 import MyActivityCard from './MyActivityCard';
 import { useMyUploadPosts } from '../../services/hooks/user/useMyUploadPosts';
-import { useVerticalSwipe } from '../../services/hooks/common/useVerticalSwipe';
-
-const TRANSITION_DURATION = 700;
-const PREFETCH_THRESHOLD = 3;
+import { useIntersectionObserver } from '../../services/hooks/common/useIntersectionObserver';
 
 export default function ActivityTab() {
   const { posts, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyUploadPosts();
 
-  const { currentIndex, containerRef, handleTouchStart, handleTouchEnd } =
-    useVerticalSwipe(posts.length, TRANSITION_DURATION);
-
-  useEffect(() => {
-    if (
-      posts.length > 0 &&
-      hasNextPage &&
-      !isFetchingNextPage &&
-      currentIndex >= posts.length - PREFETCH_THRESHOLD
-    ) {
+  const sentinelRef = useIntersectionObserver(() => {
+    if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [currentIndex, posts.length, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  });
 
   return (
-    <div
-      ref={containerRef}
-      className="relative h-full overflow-hidden"
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
-    >
+    <div>
       {isLoading && (
-        <div className="flex h-full items-center justify-center">
+        <div className="flex min-h-[320px] items-center justify-center">
           <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
         </div>
       )}
       {isError && (
-        <div className="flex h-full items-center justify-center">
+        <div className="flex min-h-[320px] items-center justify-center">
           <Text variant="REGULAR_14" className="text-red-400">
             게시글을 불러올 수 없습니다.
           </Text>
         </div>
       )}
       {!isLoading && !isError && posts.length === 0 && (
-        <div className="flex h-full items-center justify-center">
+        <div className="flex min-h-[320px] items-start justify-center pt-24">
           <Text variant="REGULAR_14" className="text-secondary-300">
             아직 활동이 없습니다.
           </Text>
@@ -53,18 +36,17 @@ export default function ActivityTab() {
       )}
       {!isLoading &&
         !isError &&
-        posts.map((post, idx) => (
-          <div
-            key={post.boardId}
-            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
-            style={{
-              transform: `translateY(${(idx - currentIndex) * 100}%)`,
-              transitionDuration: `${TRANSITION_DURATION}ms`,
-            }}
-          >
+        posts.map((post) => (
+          <div key={post.boardId}>
             <MyActivityCard post={post} />
           </div>
         ))}
+      <div ref={sentinelRef} className="h-1" />
+      {isFetchingNextPage && (
+        <div className="flex items-center justify-center py-4">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/mypage/CustomTab.tsx
+++ b/src/components/mypage/CustomTab.tsx
@@ -22,7 +22,7 @@ export default function CustomTab() {
 
   if (isError) {
     return (
-      <div className="flex h-40 items-center justify-center">
+      <div className="flex min-h-[200px] items-center justify-center">
         <Text variant="REGULAR_14" className="text-red-400">
           커스텀 목록을 불러올 수 없습니다.
         </Text>
@@ -32,7 +32,7 @@ export default function CustomTab() {
 
   if (components.length === 0) {
     return (
-      <div className="flex h-40 items-center justify-center">
+      <div className="flex min-h-[200px] items-center justify-center">
         <Text variant="REGULAR_14" className="text-secondary-300">
           커스텀한 테마/디자인이 없습니다.
         </Text>

--- a/src/components/mypage/MySavedCard.tsx
+++ b/src/components/mypage/MySavedCard.tsx
@@ -14,6 +14,7 @@ export default function MySavedCard({ post }: IMySavedCardProps) {
       imageAlt={isTheme ? '테마 미리보기' : '디자인 미리보기'}
       preferQueryKey={['my-bookmarked-posts']}
       removeOnUnbookmark
+      allowBookmarkForMyBoard
     />
   );
 }

--- a/src/components/mypage/SavedTab.tsx
+++ b/src/components/mypage/SavedTab.tsx
@@ -1,55 +1,70 @@
+import { useEffect } from 'react';
 import Text from '../common/Text';
 import MySavedCard from './MySavedCard';
 import { useMyBookmarkedPosts } from '../../services/hooks/user/useMyBookmarkedPosts';
-import { useIntersectionObserver } from '../../services/hooks/common/useIntersectionObserver';
+import { useVerticalSwipe } from '../../services/hooks/common/useVerticalSwipe';
+
+const TRANSITION_DURATION = 700;
+const PREFETCH_THRESHOLD = 3;
 
 export default function SavedTab() {
   const { posts, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyBookmarkedPosts();
 
-  const sentinelRef = useIntersectionObserver(() => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  });
+  const { currentIndex, containerRef, handleTouchStart, handleTouchEnd } =
+    useVerticalSwipe(posts.length, TRANSITION_DURATION);
 
-  if (isLoading) {
-    return (
-      <div className="flex h-40 items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="flex h-40 items-center justify-center">
-        <Text variant="REGULAR_14" className="text-red-400">
-          게시글을 불러올 수 없습니다.
-        </Text>
-      </div>
-    );
-  }
-
-  if (posts.length === 0) {
-    return (
-      <div className="flex h-40 items-center justify-center">
-        <Text variant="REGULAR_14" className="text-secondary-300">
-          저장된 게시글이 없습니다.
-        </Text>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (
+      posts.length > 0 &&
+      hasNextPage &&
+      !isFetchingNextPage &&
+      currentIndex >= posts.length - PREFETCH_THRESHOLD
+    ) {
+      fetchNextPage();
+    }
+  }, [currentIndex, posts.length, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <div>
-      {posts.map((post) => (
-        <MySavedCard key={post.boardId} post={post} />
-      ))}
-      <div ref={sentinelRef} className="h-1" />
-      {isFetchingNextPage && (
-        <div className="flex items-center justify-center py-4">
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    <div
+      ref={containerRef}
+      className="relative h-full overflow-hidden"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      {isLoading && (
+        <div className="flex h-full items-center justify-center">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
         </div>
       )}
+      {isError && (
+        <div className="flex h-full items-center justify-center">
+          <Text variant="REGULAR_14" className="text-red-400">
+            게시글을 불러올 수 없습니다.
+          </Text>
+        </div>
+      )}
+      {!isLoading && !isError && posts.length === 0 && (
+        <div className="flex h-full items-center justify-center">
+          <Text variant="REGULAR_14" className="text-secondary-300">
+            저장된 게시글이 없습니다.
+          </Text>
+        </div>
+      )}
+      {!isLoading &&
+        !isError &&
+        posts.map((post, idx) => (
+          <div
+            key={post.boardId}
+            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
+            style={{
+              transform: `translateY(${(idx - currentIndex) * 100}%)`,
+              transitionDuration: `${TRANSITION_DURATION}ms`,
+            }}
+          >
+            <MySavedCard post={post} />
+          </div>
+        ))}
     </div>
   );
 }

--- a/src/components/mypage/SavedTab.tsx
+++ b/src/components/mypage/SavedTab.tsx
@@ -1,51 +1,34 @@
-import { useEffect } from 'react';
 import Text from '../common/Text';
 import MySavedCard from './MySavedCard';
 import { useMyBookmarkedPosts } from '../../services/hooks/user/useMyBookmarkedPosts';
-import { useVerticalSwipe } from '../../services/hooks/common/useVerticalSwipe';
-
-const TRANSITION_DURATION = 700;
-const PREFETCH_THRESHOLD = 3;
+import { useIntersectionObserver } from '../../services/hooks/common/useIntersectionObserver';
 
 export default function SavedTab() {
   const { posts, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyBookmarkedPosts();
 
-  const { currentIndex, containerRef, handleTouchStart, handleTouchEnd } =
-    useVerticalSwipe(posts.length, TRANSITION_DURATION);
-
-  useEffect(() => {
-    if (
-      posts.length > 0 &&
-      hasNextPage &&
-      !isFetchingNextPage &&
-      currentIndex >= posts.length - PREFETCH_THRESHOLD
-    ) {
+  const sentinelRef = useIntersectionObserver(() => {
+    if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [currentIndex, posts.length, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  });
 
   return (
-    <div
-      ref={containerRef}
-      className="relative h-full overflow-hidden"
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
-    >
+    <div>
       {isLoading && (
-        <div className="flex h-full items-center justify-center">
+        <div className="flex min-h-[320px] items-center justify-center">
           <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
         </div>
       )}
       {isError && (
-        <div className="flex h-full items-center justify-center">
+        <div className="flex min-h-[320px] items-center justify-center">
           <Text variant="REGULAR_14" className="text-red-400">
             게시글을 불러올 수 없습니다.
           </Text>
         </div>
       )}
       {!isLoading && !isError && posts.length === 0 && (
-        <div className="flex h-full items-center justify-center">
+        <div className="flex min-h-[320px] items-start justify-center pt-24">
           <Text variant="REGULAR_14" className="text-secondary-300">
             저장된 게시글이 없습니다.
           </Text>
@@ -53,18 +36,17 @@ export default function SavedTab() {
       )}
       {!isLoading &&
         !isError &&
-        posts.map((post, idx) => (
-          <div
-            key={post.boardId}
-            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
-            style={{
-              transform: `translateY(${(idx - currentIndex) * 100}%)`,
-              transitionDuration: `${TRANSITION_DURATION}ms`,
-            }}
-          >
+        posts.map((post) => (
+          <div key={post.boardId}>
             <MySavedCard post={post} />
           </div>
         ))}
+      <div ref={sentinelRef} className="h-1" />
+      {isFetchingNextPage && (
+        <div className="flex items-center justify-center py-4">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/design-community/Detail.tsx
+++ b/src/pages/design-community/Detail.tsx
@@ -51,7 +51,7 @@ export default function Detail() {
         boards.map((p, idx) => (
           <div
             key={p.boardId}
-            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
+            className="scrollbar-hidden absolute inset-0 overflow-y-auto overscroll-contain transition-transform ease-in-out"
             style={{
               transform: `translateY(${(idx - currentIndex) * 100}%)`,
               transitionDuration: `${TRANSITION_DURATION}ms`,

--- a/src/pages/design-community/Detail.tsx
+++ b/src/pages/design-community/Detail.tsx
@@ -51,7 +51,7 @@ export default function Detail() {
         boards.map((p, idx) => (
           <div
             key={p.boardId}
-            className="absolute inset-0 transition-transform ease-in-out"
+            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
             style={{
               transform: `translateY(${(idx - currentIndex) * 100}%)`,
               transitionDuration: `${TRANSITION_DURATION}ms`,

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -77,7 +77,9 @@ export default function MyPage() {
       />
 
       {/* 탭 컨텐츠 */}
-      <div className="mt-2">{TAB_CONTENT[activeTab]}</div>
+      <div className={`mt-2 ${activeTab === 'custom' ? '' : 'h-[528px]'}`}>
+        {TAB_CONTENT[activeTab]}
+      </div>
     </main>
   );
 }

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -77,7 +77,7 @@ export default function MyPage() {
       />
 
       {/* 탭 컨텐츠 */}
-      <div className={`mt-2 ${activeTab === 'custom' ? '' : 'h-[528px]'}`}>
+      <div className="mt-2">
         {TAB_CONTENT[activeTab]}
       </div>
     </main>

--- a/src/pages/theme-community/Detail.tsx
+++ b/src/pages/theme-community/Detail.tsx
@@ -51,7 +51,7 @@ export default function Detail() {
         boards.map((p, idx) => (
           <div
             key={p.boardId}
-            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
+            className="scrollbar-hidden absolute inset-0 overflow-y-auto overscroll-contain transition-transform ease-in-out"
             style={{
               transform: `translateY(${(idx - currentIndex) * 100}%)`,
               transitionDuration: `${TRANSITION_DURATION}ms`,

--- a/src/pages/theme-community/Detail.tsx
+++ b/src/pages/theme-community/Detail.tsx
@@ -51,7 +51,7 @@ export default function Detail() {
         boards.map((p, idx) => (
           <div
             key={p.boardId}
-            className="absolute inset-0 transition-transform ease-in-out"
+            className="absolute inset-0 overflow-hidden transition-transform ease-in-out"
             style={{
               transform: `translateY(${(idx - currentIndex) * 100}%)`,
               transitionDuration: `${TRANSITION_DURATION}ms`,

--- a/src/services/api/BoardInteractionService.ts
+++ b/src/services/api/BoardInteractionService.ts
@@ -32,6 +32,16 @@ export const BoardInteractionService = {
       .put<ICommentRaw>(`/api/posts/comments/${commentId}`, { content })
       .then((res) => res.data),
 
+  likeComment: (commentId: number) =>
+    apiClient
+      .post(`/api/comments/${commentId}/like`)
+      .then((res) => res.data),
+
+  unlikeComment: (commentId: number) =>
+    apiClient
+      .delete(`/api/comments/${commentId}/like`)
+      .then((res) => res.data),
+
   bookmarkPost: (postId: number) =>
     apiClient
       .put(`/api/bookmarks/posts/${postId}`)

--- a/src/services/hooks/common/useBookmark.ts
+++ b/src/services/hooks/common/useBookmark.ts
@@ -27,7 +27,11 @@ export function useBookmark(
         await queryClient.cancelQueries({ queryKey });
         const snapshot = queryClient.getQueryData(queryKey);
         queryClient.setQueryData(queryKey, (old: unknown) =>
-          updateBoardInCache(old, postId, (item) => ({ ...item, isBookmarked: true })),
+          updateBoardInCache(old, postId, (item) => ({
+            ...item,
+            isBookmarked: true,
+            bookmarked: true,
+          })),
         );
         return { snapshot } as IBookmarkSnapshot;
       },
@@ -54,7 +58,11 @@ export function useBookmark(
         queryClient.setQueryData(queryKey, (old: unknown) =>
           removeOnUnbookmark
             ? removeBoardFromCache(old, postId)
-            : updateBoardInCache(old, postId, (item) => ({ ...item, isBookmarked: false })),
+            : updateBoardInCache(old, postId, (item) => ({
+                ...item,
+                isBookmarked: false,
+                bookmarked: false,
+              })),
         );
         return { snapshot } as IBookmarkSnapshot;
       },

--- a/src/services/hooks/common/useCommentLike.ts
+++ b/src/services/hooks/common/useCommentLike.ts
@@ -1,0 +1,114 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useDeleteMutation, usePostMutation } from '../../api/useApi';
+import { BoardInteractionService } from '../../api/BoardInteractionService';
+import type { ICommentRaw } from '../../../types/community/theme';
+
+type ICommentLikeSnapshot = { snapshot: ICommentRaw[] | undefined };
+
+function getNumberValue(...values: Array<number | undefined>): number {
+  return values.find((value) => typeof value === 'number') ?? 0;
+}
+
+export function getCommentLikeCount(comment: ICommentRaw): number {
+  return getNumberValue(
+    comment.likes,
+    comment.likeCount,
+    comment.likedCount,
+    comment.likesCount,
+    comment.like_count,
+    comment.liked_count,
+    comment.likes_count,
+  );
+}
+
+export function getCommentIsLiked(comment: ICommentRaw): boolean {
+  return comment.isLiked ?? comment.liked ?? false;
+}
+
+function updateCommentLikeState(comment: ICommentRaw, commentId: number, isLiked: boolean) {
+  if (comment.commentId !== commentId) return comment;
+
+  const currentCount = getCommentLikeCount(comment);
+  const nextCount = Math.max(0, currentCount + (isLiked ? 1 : -1));
+
+  return {
+    ...comment,
+    isLiked,
+    liked: isLiked,
+    likes: nextCount,
+    likeCount: comment.likeCount === undefined ? comment.likeCount : nextCount,
+    likedCount: comment.likedCount === undefined ? comment.likedCount : nextCount,
+    likesCount: comment.likesCount === undefined ? comment.likesCount : nextCount,
+    like_count: comment.like_count === undefined ? comment.like_count : nextCount,
+    liked_count: comment.liked_count === undefined ? comment.liked_count : nextCount,
+    likes_count: comment.likes_count === undefined ? comment.likes_count : nextCount,
+  };
+}
+
+export function useCommentLike(boardId: number, comment: ICommentRaw) {
+  const queryClient = useQueryClient();
+  const queryKey = ['comments', boardId];
+  const isLiked = getCommentIsLiked(comment);
+  const likes = getCommentLikeCount(comment);
+
+  const updateComments = async (nextIsLiked: boolean) => {
+    await queryClient.cancelQueries({ queryKey });
+    const snapshot = queryClient.getQueryData<ICommentRaw[]>(queryKey);
+
+    queryClient.setQueryData<ICommentRaw[]>(queryKey, (old) =>
+      old?.map((item) => updateCommentLikeState(item, comment.commentId, nextIsLiked)),
+    );
+
+    return { snapshot } as ICommentLikeSnapshot;
+  };
+
+  const rollback = (context: unknown, fallbackIsLiked: boolean) => {
+    const ctx = context as ICommentLikeSnapshot | undefined;
+    if (ctx?.snapshot !== undefined) {
+      queryClient.setQueryData(queryKey, ctx.snapshot);
+      return;
+    }
+
+    queryClient.setQueryData<ICommentRaw[]>(queryKey, (old) =>
+      old?.map((item) => updateCommentLikeState(item, comment.commentId, fallbackIsLiked)),
+    );
+  };
+
+  const { mutate: likeComment, isPending: isLikePending } = usePostMutation<unknown, number>(
+    (commentId) => BoardInteractionService.likeComment(commentId),
+    {
+      onMutate: () => updateComments(true),
+      onError: (_err, _vars, context) => rollback(context, false),
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey });
+      },
+    },
+  );
+
+  const { mutate: unlikeComment, isPending: isUnlikePending } = useDeleteMutation<unknown, number>(
+    (commentId) => BoardInteractionService.unlikeComment(commentId),
+    {
+      onMutate: () => updateComments(false),
+      onError: (_err, _vars, context) => rollback(context, true),
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey });
+      },
+    },
+  );
+
+  const toggleCommentLike = () => {
+    if (isLiked) {
+      unlikeComment(comment.commentId);
+      return;
+    }
+
+    likeComment(comment.commentId);
+  };
+
+  return {
+    isLiked,
+    likes,
+    toggleCommentLike,
+    isPending: isLikePending || isUnlikePending,
+  };
+}

--- a/src/services/hooks/common/useVerticalSwipe.ts
+++ b/src/services/hooks/common/useVerticalSwipe.ts
@@ -1,10 +1,23 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 
+function findScrollableAncestor(node: HTMLElement | null): HTMLElement | null {
+  let n: HTMLElement | null = node?.parentElement ?? null;
+  while (n) {
+    const style = getComputedStyle(n);
+    if (/(auto|scroll)/.test(style.overflowY) && n.scrollHeight > n.clientHeight) {
+      return n;
+    }
+    n = n.parentElement;
+  }
+  return null;
+}
+
 export function useVerticalSwipe(boardsLength: number, transitionDuration: number) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const stateRef = useRef({ currentIndex: 0, isAnimating: false, boardsLength });
   const touchStartY = useRef(0);
+  const touchStartScrollTop = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -41,6 +54,16 @@ export function useVerticalSwipe(boardsLength: number, transitionDuration: numbe
     if (!el) return;
 
     const handler = (e: WheelEvent) => {
+      const scrollEl = findScrollableAncestor(el);
+      if (scrollEl) {
+        const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
+        const atBottom = scrollEl.scrollTop >= maxScroll - 1;
+        const atTop = scrollEl.scrollTop <= 1;
+
+        if (e.deltaY > 0 && !atBottom) return;
+        if (e.deltaY < 0 && stateRef.current.currentIndex === 0 && !atTop) return;
+      }
+
       e.preventDefault();
       if (e.deltaY > 0) goTo(stateRef.current.currentIndex + 1);
       else goTo(stateRef.current.currentIndex - 1);
@@ -52,14 +75,28 @@ export function useVerticalSwipe(boardsLength: number, transitionDuration: numbe
 
   const handleTouchStart = (e: React.TouchEvent) => {
     touchStartY.current = e.touches[0].clientY;
+    const scrollEl = findScrollableAncestor(containerRef.current);
+    touchStartScrollTop.current = scrollEl?.scrollTop ?? 0;
   };
 
   const handleTouchEnd = (e: React.TouchEvent) => {
     const delta = touchStartY.current - e.changedTouches[0].clientY;
-    if (Math.abs(delta) > 50) {
-      if (delta > 0) goTo(stateRef.current.currentIndex + 1);
-      else goTo(stateRef.current.currentIndex - 1);
+    if (Math.abs(delta) <= 50) return;
+
+    const scrollEl = findScrollableAncestor(containerRef.current);
+    if (scrollEl) {
+      const scrollChange = Math.abs(scrollEl.scrollTop - touchStartScrollTop.current);
+      if (scrollChange > 10) return;
+
+      const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
+      const atBottom = scrollEl.scrollTop >= maxScroll - 1;
+      const atTop = scrollEl.scrollTop <= 1;
+      if (delta > 0 && !atBottom) return;
+      if (delta < 0 && stateRef.current.currentIndex === 0 && !atTop) return;
     }
+
+    if (delta > 0) goTo(stateRef.current.currentIndex + 1);
+    else goTo(stateRef.current.currentIndex - 1);
   };
 
   return { currentIndex, containerRef, handleTouchStart, handleTouchEnd };

--- a/src/services/hooks/common/useVerticalSwipe.ts
+++ b/src/services/hooks/common/useVerticalSwipe.ts
@@ -1,28 +1,50 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 
-function findScrollableAncestor(node: HTMLElement | null): HTMLElement | null {
-  let n: HTMLElement | null = node?.parentElement ?? null;
-  while (n) {
-    const style = getComputedStyle(n);
-    if (/(auto|scroll)/.test(style.overflowY) && n.scrollHeight > n.clientHeight) {
-      return n;
-    }
-    n = n.parentElement;
+const SCROLL_EDGE_TOLERANCE = 1;
+
+function getTargetElement(target: EventTarget | null): HTMLElement | null {
+  if (!(target instanceof Node)) return null;
+  if (target instanceof HTMLElement) return target;
+
+  return target.parentElement;
+}
+
+function isScrollableY(node: HTMLElement): boolean {
+  const style = getComputedStyle(node);
+  return /(auto|scroll)/.test(style.overflowY) && node.scrollHeight > node.clientHeight;
+}
+
+function getMaxScrollTop(node: HTMLElement): number {
+  return Math.max(0, node.scrollHeight - node.clientHeight);
+}
+
+function findScrollableAncestorWithin(
+  node: HTMLElement | null,
+  boundary: HTMLElement | null,
+): HTMLElement | null {
+  if (!node || !boundary || !boundary.contains(node)) return null;
+
+  let current: HTMLElement | null = node;
+  while (current) {
+    if (isScrollableY(current)) return current;
+    if (current === boundary) break;
+    current = current.parentElement;
   }
+
   return null;
 }
 
-export function useVerticalSwipe(boardsLength: number, transitionDuration: number) {
+export function useVerticalSwipe(itemsLength: number, transitionDuration: number) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
-  const stateRef = useRef({ currentIndex: 0, isAnimating: false, boardsLength });
+  const stateRef = useRef({ currentIndex: 0, isAnimating: false, itemsLength });
   const touchStartY = useRef(0);
   const touchStartScrollTop = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    stateRef.current.boardsLength = boardsLength;
-  }, [boardsLength]);
+    stateRef.current.itemsLength = itemsLength;
+  }, [itemsLength]);
 
   useEffect(() => {
     return () => {
@@ -33,8 +55,14 @@ export function useVerticalSwipe(boardsLength: number, transitionDuration: numbe
   const goTo = useCallback(
     (idx: number) => {
       if (stateRef.current.isAnimating) return;
-      const next = Math.max(0, Math.min(idx, stateRef.current.boardsLength - 1));
+
+      const next = Math.max(0, Math.min(idx, stateRef.current.itemsLength - 1));
       if (next === stateRef.current.currentIndex) return;
+
+      const nextSlide = containerRef.current?.children.item(next);
+      if (nextSlide instanceof HTMLElement) {
+        nextSlide.scrollTop = 0;
+      }
 
       stateRef.current.isAnimating = true;
       stateRef.current.currentIndex = next;
@@ -50,18 +78,20 @@ export function useVerticalSwipe(boardsLength: number, transitionDuration: numbe
   );
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
+    const container = containerRef.current;
+    if (!container) return;
 
-    const handler = (e: WheelEvent) => {
-      const scrollEl = findScrollableAncestor(el);
+    const handleWheel = (e: WheelEvent) => {
+      const target = getTargetElement(e.target);
+      const scrollEl = findScrollableAncestorWithin(target, container);
+
       if (scrollEl) {
-        const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
-        const atBottom = scrollEl.scrollTop >= maxScroll - 1;
-        const atTop = scrollEl.scrollTop <= 1;
+        const maxScroll = getMaxScrollTop(scrollEl);
+        const atBottom = scrollEl.scrollTop >= maxScroll - SCROLL_EDGE_TOLERANCE;
+        const atTop = scrollEl.scrollTop <= SCROLL_EDGE_TOLERANCE;
 
         if (e.deltaY > 0 && !atBottom) return;
-        if (e.deltaY < 0 && stateRef.current.currentIndex === 0 && !atTop) return;
+        if (e.deltaY < 0 && !atTop) return;
       }
 
       e.preventDefault();
@@ -69,13 +99,15 @@ export function useVerticalSwipe(boardsLength: number, transitionDuration: numbe
       else goTo(stateRef.current.currentIndex - 1);
     };
 
-    el.addEventListener('wheel', handler, { passive: false });
-    return () => el.removeEventListener('wheel', handler);
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => container.removeEventListener('wheel', handleWheel);
   }, [goTo]);
 
   const handleTouchStart = (e: React.TouchEvent) => {
     touchStartY.current = e.touches[0].clientY;
-    const scrollEl = findScrollableAncestor(containerRef.current);
+
+    const target = getTargetElement(e.target);
+    const scrollEl = findScrollableAncestorWithin(target, containerRef.current);
     touchStartScrollTop.current = scrollEl?.scrollTop ?? 0;
   };
 
@@ -83,16 +115,19 @@ export function useVerticalSwipe(boardsLength: number, transitionDuration: numbe
     const delta = touchStartY.current - e.changedTouches[0].clientY;
     if (Math.abs(delta) <= 50) return;
 
-    const scrollEl = findScrollableAncestor(containerRef.current);
+    const target = getTargetElement(e.target);
+    const scrollEl = findScrollableAncestorWithin(target, containerRef.current);
+
     if (scrollEl) {
       const scrollChange = Math.abs(scrollEl.scrollTop - touchStartScrollTop.current);
       if (scrollChange > 10) return;
 
-      const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
-      const atBottom = scrollEl.scrollTop >= maxScroll - 1;
-      const atTop = scrollEl.scrollTop <= 1;
+      const maxScroll = getMaxScrollTop(scrollEl);
+      const atBottom = scrollEl.scrollTop >= maxScroll - SCROLL_EDGE_TOLERANCE;
+      const atTop = scrollEl.scrollTop <= SCROLL_EDGE_TOLERANCE;
+
       if (delta > 0 && !atBottom) return;
-      if (delta < 0 && stateRef.current.currentIndex === 0 && !atTop) return;
+      if (delta < 0 && !atTop) return;
     }
 
     if (delta > 0) goTo(stateRef.current.currentIndex + 1);

--- a/src/types/community/theme.ts
+++ b/src/types/community/theme.ts
@@ -66,8 +66,18 @@ export interface IThemeBoard {
 export interface ICommentRaw {
   commentId: number;
   userEmail: string;
+  userName?: string;
   content: string;
   createdAt: string;
+  isLiked?: boolean;
+  liked?: boolean;
+  likes?: number;
+  likeCount?: number;
+  likedCount?: number;
+  likesCount?: number;
+  like_count?: number;
+  liked_count?: number;
+  likes_count?: number;
 }
 
 export type TabId = 'activity' | 'keyword';

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -7,6 +7,11 @@ export function isInfiniteCache(data: unknown): data is IInfiniteCache {
   return !!data && typeof data === 'object' && Array.isArray((data as IInfiniteCache).pages);
 }
 
+function getBoardId(item: Record<string, unknown>): number | undefined {
+  const id = item.boardId ?? item.postId;
+  return typeof id === 'number' ? id : undefined;
+}
+
 export function updateBoardInCache(
   data: unknown,
   boardId: number,
@@ -17,12 +22,12 @@ export function updateBoardInCache(
     return {
       ...data,
       pages: data.pages.map((page) =>
-        page.map((item) => ((item.boardId as number) === boardId ? updater(item) : item)),
+        page.map((item) => (getBoardId(item) === boardId ? updater(item) : item)),
       ),
     };
   }
   const obj = data as Record<string, unknown>;
-  if ((obj.boardId as number) === boardId) return updater(obj);
+  if (getBoardId(obj) === boardId) return updater(obj);
   return data;
 }
 
@@ -32,7 +37,7 @@ export function removeBoardFromCache(data: unknown, boardId: number): unknown {
     return {
       ...data,
       pages: data.pages.map((page) =>
-        page.filter((item) => (item.boardId as number) !== boardId),
+        page.filter((item) => getBoardId(item) !== boardId),
       ),
     };
   }


### PR DESCRIPTION
- MyPage 레이아웃 수정: flex h-full flex-col 제거, 프로필 자연 스크롤, TabMenu sticky 고정
- fp-swipe 탭(내 활동·저장된)에만 h-[528px] 적용, 내 커스텀 탭은 자연 flow로 통합
- useVerticalSwipe에 외부 스크롤 조상 자동 탐지 + wheel/touch gating 추가 (외부 스크롤 여유 있으면 native 스크롤 허용, 소진 시 fp-swipe 전환)
- fp-swipe 카드 wrapper에 overflow-hidden 추가 — 긴 게시글이 다음 카드 영역 침범 방지 (ActivityTab, SavedTab, theme/design Detail 공통 적용)
- CustomTab 내부 스크롤 제거: h-full overflow-y-auto → 자연 높이, Outlet 스크롤로 통합