### PR TITLE
홈 화면 개발 (#60)

### DIFF
--- a/src/components/community/BoardDetailCard.tsx
+++ b/src/components/community/BoardDetailCard.tsx
@@ -9,6 +9,7 @@ import { useCommentActions } from '../../services/hooks/common/useCommentActions
 import { usePrefer } from '../../services/hooks/common/usePrefer';
 import { useBookmark } from '../../services/hooks/common/useBookmark';
 import { useAuthStore } from '../../stores/authStore';
+import { formatDate } from '../../utils/date';
 import ImageSlider from '../common/ImageSlider';
 import CommentModal from './CommentModal';
 import Confirm from '../common/Confirm';
@@ -144,7 +145,7 @@ export default function BoardDetailCard({
           )}
           <div className="flex min-w-0 flex-col">
             <Text variant="BOLD_15" className="truncate">{board.userName}</Text>
-            <Text variant="REGULAR_10" className="text-secondary-400">{board.createdAt}</Text>
+            <Text variant="REGULAR_10" className="text-secondary-400">{formatDate(board.createdAt)}</Text>
           </div>
         </div>
 

--- a/src/layouts/MobileHeader.tsx
+++ b/src/layouts/MobileHeader.tsx
@@ -7,29 +7,34 @@ import { cn } from "../utils/cn";
 interface IMobileHeaderProps {
   title: string;
   showBackArrow?: boolean;
+  showMenuButton?: boolean;
   className?: string;
 }
 
-export default function MobileHeader({ title, showBackArrow, className }: IMobileHeaderProps) {
+export default function MobileHeader({ title, showBackArrow, showMenuButton, className }: IMobileHeaderProps) {
   const navigate = useNavigate();
   return (
     <header className={cn("relative flex shrink-0 items-center justify-center bg-white px-4 pt-10", className)}>
-      {/* 왼쪽 영역: 뒤로가기 버튼 */}
-      <div className="absolute left-4">
+      <div className="absolute left-4 flex h-6 w-6 items-center justify-center">
         {showBackArrow && (
-          <button onClick={() => navigate(-1)} className="p-1">
+          <button type="button" onClick={() => navigate(-1)} className="p-1" aria-label="뒤로가기">
             <BackArrowIcon />
+          </button>
+        )}
+        {showMenuButton && !showBackArrow && (
+          <button type="button" className="flex h-6 w-6 flex-col justify-center gap-[5px]" aria-label="메뉴 열기">
+            <span className="h-[2px] w-[18px] rounded-full bg-black" />
+            <span className="h-[2px] w-[18px] rounded-full bg-black" />
+            <span className="h-[2px] w-[18px] rounded-full bg-black" />
           </button>
         )}
       </div>
 
-      {/* 중앙 영역: 로고+제목 */}
       <div className="flex items-center gap-2">
         <HeaderIcon className="h-5 w-6" />
         <Text variant="SEMIBOLD_15">{title}</Text>
       </div>
 
-      {/* 오른쪽 영역(현재 비어있음) */}
       <div className="absolute right-4 w-6" />
     </header>
   )

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -1,8 +1,10 @@
 import { Outlet, useLocation } from "react-router-dom";
+import { useCallback, useMemo, useRef } from "react";
 import BottomTabBar from "./BottomTabBar";
 import MobileHeader from "./MobileHeader";
 
 export default function MobileLayout() {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { pathname } = useLocation()
   const isHome: boolean = pathname === "/"
   const isCommunity: boolean = pathname.startsWith("/community")
@@ -21,14 +23,21 @@ export default function MobileLayout() {
   // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/6'의 경우 2로 봄)
   // 경로의 끝에 /가 올 경우 정확하게 처리하지 못할 수 있어 filter(Boolean)을 사용하여 빈 문자열을 제거
   const showBackArrow: boolean = pathname.split('/').filter(Boolean).length >= 2;
+  const scrollToTop = useCallback(() => {
+    scrollContainerRef.current?.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, []);
+  const outletContext = useMemo(() => ({ scrollToTop }), [scrollToTop]);
 
   return (
     <div className="flex min-h-screen items-start justify-center bg-white py-4">
       <div id="phone-root" className="relative flex h-[700px] w-[340px] flex-col overflow-hidden border border-secondary-200">
         {hasHeader && <MobileHeader title={headerTitle} showBackArrow={showBackArrow} showMenuButton={isHome} />}
 
-        <div className={`scrollbar-hidden flex-1 overflow-y-auto ${isCommunityDetail || isDesignDetail ? "" : "pb-16"}`}>
-          <Outlet />
+        <div
+          ref={scrollContainerRef}
+          className={`scrollbar-hidden flex-1 overflow-y-auto ${isCommunityDetail || isDesignDetail ? "" : "pb-16"}`}
+        >
+          <Outlet context={outletContext} />
         </div>
 
         <BottomTabBar isHome={isHome} isCommunity={isCommunity} isDesign={isDesign} isMyPage={pathname.startsWith("/mypage")} />

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -15,7 +15,7 @@ export default function MobileLayout() {
   const isCommunityDetail: boolean = pathname.split('/').filter(Boolean).length >= 2 && isCommunity && !isBoardWrite && !isBoardEdit
   const isDesignDetail: boolean = pathname.split('/').filter(Boolean).length >= 2 && isDesign && !isDesignBoardWrite && !isDesignBoardEdit
   const hasHeader: boolean = isHome || isCommunity || isDesign || isMyPage
-  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isCommunity ? "테마 커뮤니티" : isDesign ? "디자인 커뮤니티" : isMyPage ? "마이페이지" : "고정 헤더"
+  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "테마 커뮤니티" : isDesign ? "디자인 커뮤니티" : isMyPage ? "마이페이지" : "고정 헤더"
 
   // 뒤로가기 버튼을 보여주어야 하는 경로인지 판별
   // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/6'의 경우 2로 봄)
@@ -25,7 +25,7 @@ export default function MobileLayout() {
   return (
     <div className="flex min-h-screen items-start justify-center bg-white py-4">
       <div id="phone-root" className="relative flex h-[700px] w-[340px] flex-col overflow-hidden border border-secondary-200">
-        {hasHeader && <MobileHeader title={headerTitle} showBackArrow={showBackArrow} />}
+        {hasHeader && <MobileHeader title={headerTitle} showBackArrow={showBackArrow} showMenuButton={isHome} />}
 
         <div className={`scrollbar-hidden flex-1 overflow-y-auto ${isCommunityDetail || isDesignDetail ? "" : "pb-16"}`}>
           <Outlet />

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useState } from 'react';
+import Text from '../../components/common/Text';
+import { useIntersectionObserver } from '../../services/hooks/common/useIntersectionObserver';
+import {
+  type HomeThemeListType,
+  useHomeThemes,
+} from '../../services/hooks/theme/useHomeThemes';
+import type { IHomeTheme } from '../../types/community/theme';
+import { cn } from '../../utils/cn';
+
+type HomeTabId = 'create' | 'popular' | 'bookmarked';
+
+const TABS: { id: HomeTabId; label: string }[] = [
+  { id: 'create', label: '테마 제작' },
+  { id: 'popular', label: '인기 테마' },
+  { id: 'bookmarked', label: '저장 테마' },
+];
+
+function HomeTabs({
+  activeTab,
+  onTabChange,
+}: {
+  activeTab: HomeTabId;
+  onTabChange: (tab: HomeTabId) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 bg-white px-4 pt-5 text-center">
+      {TABS.map((tab) => {
+        const isActive = activeTab === tab.id;
+
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onTabChange(tab.id)}
+            className={cn("pb-2 transition-colors", isActive ? "text-primary" : "text-black")}
+          >
+            <span
+              className={cn(
+                "inline-flex border-b-2 px-1 pb-2",
+                isActive ? "border-primary" : "border-transparent",
+              )}
+            >
+              <Text variant={isActive ? "SEMIBOLD_15" : "LIGHT_15"}>{tab.label}</Text>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function HomeThemeCard({ theme }: { theme: IHomeTheme }) {
+  return (
+    <article className="aspect-[94/173] overflow-hidden rounded-[5px] border border-secondary-200 bg-[#f9f9fb]">
+      {theme.previewImageUrl ? (
+        <img src={theme.previewImageUrl} alt={theme.themeName} className="h-full w-full object-cover" />
+      ) : (
+        <div className="h-full w-full bg-[#f9f9fb]" aria-label={theme.themeName} />
+      )}
+    </article>
+  );
+}
+
+function ThemeCardSkeleton() {
+  return <div className="aspect-[94/173] animate-pulse rounded-[5px] border border-secondary-200 bg-[#f9f9fb]" />;
+}
+
+function HomeThemeGrid({ type }: { type: HomeThemeListType }) {
+  const { themes, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useHomeThemes(type);
+
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const sentinelRef = useIntersectionObserver(handleIntersect);
+  const emptyMessage = type === 'popular' ? '인기 테마가 없습니다.' : '저장한 테마가 없습니다.';
+
+  if (isLoading) {
+    return (
+      <section className="grid grid-cols-3 gap-x-[15px] gap-y-10 px-[22px] pt-3">
+        {Array.from({ length: 9 }).map((_, index) => (
+          <ThemeCardSkeleton key={index} />
+        ))}
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex min-h-[280px] items-center justify-center">
+        <Text variant="REGULAR_14" className="text-red-400">
+          테마 목록을 불러올 수 없습니다.
+        </Text>
+      </div>
+    );
+  }
+
+  if (themes.length === 0) {
+    return (
+      <div className="flex min-h-[280px] items-center justify-center">
+        <Text variant="REGULAR_14" className="text-secondary-300">
+          {emptyMessage}
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <section className="grid grid-cols-3 gap-x-[15px] gap-y-10 px-[22px] pt-3">
+      {themes.map((theme) => (
+        <HomeThemeCard key={theme.themeComponentId} theme={theme} />
+      ))}
+      <div ref={sentinelRef} className="col-span-3 h-1" />
+      {isFetchingNextPage && (
+        <div className="col-span-3 flex justify-center py-3">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PreparingTab() {
+  return (
+    <div className="flex min-h-[360px] items-center justify-center">
+      <Text variant="REGULAR_15" className="text-black">
+        아직 준비중입니다...
+      </Text>
+    </div>
+  );
+}
+
+export default function Home() {
+  const [activeTab, setActiveTab] = useState<HomeTabId>('popular');
+
+  return (
+    <main className="min-h-full bg-white">
+      <HomeTabs activeTab={activeTab} onTabChange={setActiveTab} />
+      {activeTab === 'create' && <PreparingTab />}
+      {activeTab === 'popular' && <HomeThemeGrid type="popular" />}
+      {activeTab === 'bookmarked' && <HomeThemeGrid type="bookmarked" />}
+    </main>
+  );
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useLayoutEffect, useState } from 'react';
+import { useOutletContext } from 'react-router-dom';
 import Text from '../../components/common/Text';
 import { useIntersectionObserver } from '../../services/hooks/common/useIntersectionObserver';
 import {
@@ -9,6 +10,10 @@ import type { IHomeTheme } from '../../types/community/theme';
 import { cn } from '../../utils/cn';
 
 type HomeTabId = 'create' | 'popular' | 'bookmarked';
+
+interface IMobileLayoutOutletContext {
+  scrollToTop: () => void;
+}
 
 const TABS: { id: HomeTabId; label: string }[] = [
   { id: 'create', label: '테마 제작' },
@@ -24,7 +29,7 @@ function HomeTabs({
   onTabChange: (tab: HomeTabId) => void;
 }) {
   return (
-    <div className="grid grid-cols-3 bg-white px-4 pt-5 text-center">
+    <div className="sticky top-0 z-20 grid grid-cols-3 bg-white px-4 pt-5 text-center">
       {TABS.map((tab) => {
         const isActive = activeTab === tab.id;
 
@@ -134,6 +139,11 @@ function PreparingTab() {
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState<HomeTabId>('popular');
+  const { scrollToTop } = useOutletContext<IMobileLayoutOutletContext>();
+
+  useLayoutEffect(() => {
+    scrollToTop();
+  }, [activeTab, scrollToTop]);
 
   return (
     <main className="min-h-full bg-white">

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes } from "react-router-dom";
-import App from "../App.tsx";
+import Home from "../pages/home/Home.tsx";
 import ThemeCommunityList from "../pages/theme-community/List.tsx";
 import ThemeCommunityDetail from "../pages/theme-community/Detail.tsx";
 import DesignCommunityList from "../pages/design-community/List.tsx";
@@ -44,7 +44,7 @@ export default function AppRoutes() {
         <Route path="/auth/kakao/callback" element={<KakaoCallback />} />
         <Route element={<ProtectedRoutes />}>
           <Route element={<MobileLayout />}>
-            <Route path="/" element={<App />} />
+            <Route path="/" element={<Home />} />
             <Route path="/community" element={<ThemeCommunityList />} />
             <Route path="/community/write" element={<BoardThemeSelect />} />
             <Route path="/community/write/post" element={<BoardWrite />} />

--- a/src/services/api/ApiClient.ts
+++ b/src/services/api/ApiClient.ts
@@ -41,7 +41,7 @@ apiClient.interceptors.response.use(
       try {
         // 순환 참조 방지를 위해 axios raw 인스턴스로 직접 호출합니다.
         // httpOnly 쿠키가 자동으로 전송되므로 body에 토큰 불필요합니다.
-        await axios.post(`${BASE_URL}/api/auth/token`, {}, { withCredentials: true });
+        await axios.post(`${BASE_URL}/api/auth/reissue`, {}, { withCredentials: true });
         useAuthStore.getState().setAuthenticated();
         processQueue(null);
         return apiClient(originalRequest);

--- a/src/services/api/AuthService.ts
+++ b/src/services/api/AuthService.ts
@@ -21,14 +21,6 @@ export const AuthService = {
       .then((res) => res.data),
 
   /**
-   * 토큰 재발급: httpOnly 쿠키의 refreshToken으로 토큰 갱신 (body 불필요)
-   */
-  refresh: () =>
-    apiClient
-      .post<IAuthResponse>('/api/auth/token')
-      .then((res) => res.data),
-
-  /**
    * 로그아웃: 서버에서 httpOnly 쿠키 무효화
    */
   logout: () =>

--- a/src/services/api/ThemeService.ts
+++ b/src/services/api/ThemeService.ts
@@ -1,8 +1,20 @@
 import apiClient from './ApiClient';
-import type { IThemeBoardRaw, IThemeBoardDetailsRaw, IUserThemeRaw, IBoardCreateResponseRaw } from '../../types/community/theme';
+import type {
+  IBoardCreateResponseRaw,
+  IHomeThemeRaw,
+  IThemeBoardDetailsRaw,
+  IThemeBoardRaw,
+  IUserThemeRaw,
+} from '../../types/community/theme';
 
 interface IGetThemeBoardDetailsParams {
   pinnedPostId: number;
+  page: number;
+  size: number;
+  sort?: 'asc' | 'desc';
+}
+
+interface IGetHomeThemesParams {
   page: number;
   size: number;
   sort?: 'asc' | 'desc';
@@ -24,6 +36,16 @@ export const ThemeService = {
   getUserThemes: (userEmail: string, page: number, size: number) =>
     apiClient
       .get<IUserThemeRaw[]>(`/api/themes/user/${userEmail}`, { params: { page, size } })
+      .then((res) => res.data),
+
+  getPopularThemes: ({ page, size, sort = 'desc' }: IGetHomeThemesParams) =>
+    apiClient
+      .get<IHomeThemeRaw[]>('/api/themes/popular', { params: { page, size, sort } })
+      .then((res) => res.data),
+
+  getBookmarkedThemes: ({ page, size, sort = 'desc' }: IGetHomeThemesParams) =>
+    apiClient
+      .get<IHomeThemeRaw[]>('/api/themes/bookmarked', { params: { page, size, sort } })
       .then((res) => res.data),
 
   createThemeBoard: (formData: FormData) =>

--- a/src/services/hooks/common/useIntersectionObserver.ts
+++ b/src/services/hooks/common/useIntersectionObserver.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 /**
  * Intersection Observer를 이용한 요소 가시성 감지 훅
@@ -11,8 +11,8 @@ import { useEffect, useRef } from 'react';
  *   <div ref={sentinelRef} />
  */
 export function useIntersectionObserver(onIntersect: () => void) {
-  const ref = useRef<HTMLDivElement>(null);
   const callbackRef = useRef(onIntersect);
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
   // 렌더링 중 ref.current를 직접 수정하면 React 동시성 렌더링에서
   // 렌더가 중단·재시도될 때 콜백이 불완전한 상태로 적용될 수 있습니다.
@@ -22,17 +22,23 @@ export function useIntersectionObserver(onIntersect: () => void) {
     callbackRef.current = onIntersect;
   });
 
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
+  const sentinelRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+
+    if (!node) return;
 
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting) callbackRef.current();
     });
 
-    observer.observe(el);
-    return () => observer.disconnect();
+    observer.observe(node);
+    observerRef.current = observer;
   }, []);
 
-  return ref;
+  useEffect(() => {
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  return sentinelRef;
 }

--- a/src/services/hooks/theme/useHomeThemes.ts
+++ b/src/services/hooks/theme/useHomeThemes.ts
@@ -7,13 +7,27 @@ const PAGE_SIZE = 12;
 
 export type HomeThemeListType = 'popular' | 'bookmarked';
 
+function isSnakeHomeTheme(item: IHomeThemeRaw): item is Extract<IHomeThemeRaw, { preview_image_url: string }> {
+  return 'preview_image_url' in item;
+}
+
 function mapHomeTheme(item: IHomeThemeRaw): IHomeTheme {
+  if (!isSnakeHomeTheme(item)) {
+    return {
+      themeComponentId: item.themeComponentId,
+      previewImageUrl: item.previewImageUrl,
+      themeName: item.themeName,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    };
+  }
+
   return {
-    themeComponentId: item.themeComponentId,
-    previewImageUrl: item.previewImageUrl,
-    themeName: item.themeName,
-    createdAt: item.createdAt,
-    updatedAt: item.updatedAt,
+    themeComponentId: item.theme_component_id,
+    previewImageUrl: item.preview_image_url,
+    themeName: item.theme_name,
+    createdAt: item.created_at,
+    updatedAt: item.updated_at,
   };
 }
 

--- a/src/services/hooks/theme/useHomeThemes.ts
+++ b/src/services/hooks/theme/useHomeThemes.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { ThemeService } from '../../api/ThemeService';
+import type { IHomeTheme, IHomeThemeRaw } from '../../../types/community/theme';
+
+const PAGE_SIZE = 12;
+
+export type HomeThemeListType = 'popular' | 'bookmarked';
+
+function mapHomeTheme(item: IHomeThemeRaw): IHomeTheme {
+  return {
+    themeComponentId: item.themeComponentId,
+    previewImageUrl: item.previewImageUrl,
+    themeName: item.themeName,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
+export function useHomeThemes(type: HomeThemeListType) {
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ['home-themes', type],
+    queryFn: ({ pageParam }) =>
+      type === 'popular'
+        ? ThemeService.getPopularThemes({ page: pageParam, size: PAGE_SIZE })
+        : ThemeService.getBookmarkedThemes({ page: pageParam, size: PAGE_SIZE }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length < PAGE_SIZE ? undefined : allPages.length,
+  });
+
+  const themes = useMemo<IHomeTheme[]>(
+    () => (data?.pages ?? []).flat().map(mapHomeTheme),
+    [data],
+  );
+
+  return { themes, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage };
+}

--- a/src/types/community/theme.ts
+++ b/src/types/community/theme.ts
@@ -112,14 +112,24 @@ export interface IUserTheme {
   images: { designComponentId: number }[];
 }
 
-// GET /api/themes/popular, /api/themes/bookmarked 응답 항목
-export interface IHomeThemeRaw {
+interface IHomeThemeSnakeRaw {
+  theme_component_id: number;
+  preview_image_url: string;
+  theme_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface IHomeThemeCamelRaw {
   themeComponentId: number;
   previewImageUrl: string;
   themeName: string;
   createdAt: string;
   updatedAt: string;
 }
+
+// GET /api/themes/popular, /api/themes/bookmarked 응답 항목
+export type IHomeThemeRaw = IHomeThemeSnakeRaw | IHomeThemeCamelRaw;
 
 export interface IHomeTheme {
   themeComponentId: number;

--- a/src/types/community/theme.ts
+++ b/src/types/community/theme.ts
@@ -112,6 +112,23 @@ export interface IUserTheme {
   images: { designComponentId: number }[];
 }
 
+// GET /api/themes/popular, /api/themes/bookmarked 응답 항목
+export interface IHomeThemeRaw {
+  themeComponentId: number;
+  previewImageUrl: string;
+  themeName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IHomeTheme {
+  themeComponentId: number;
+  previewImageUrl: string;
+  themeName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // POST /api/theme-boards 응답 - 서버 원본 형식 (snake_case)
 export interface IBoardCreateResponseRaw {
   title: string;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,21 @@
+export function formatDate(value?: string | null) {
+  if (!value) return '';
+
+  const isoDate = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoDate) {
+    const [, year, month, day] = isoDate;
+    return `${year}.${month}.${day}`;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+    .format(date)
+    .replace(/\.\s?/g, '.')
+    .replace(/\.$/, '');
+}


### PR DESCRIPTION
- Fce.refresh 메서드를 제거해 재발급 흐름을 인터셉터 중심으로 정리
- 검증: npm run lintigma 홈 시안을 기준으로 루트 경로에 Home 화면을 신규 연결
- 홈 화면에 테마 제작, 인기 테마, 저장 테마 탭 UI를 추가하고 테마 제작 탭은 준비중 상태로 표시
- 인기 테마와 저장 테마 목록에 /api/themes/popular, /api/themes/bookmarked API 연동 및 무한 스크롤 처리 추가
- 홈 테마 카드 그리드, 로딩, 에러, 빈 상태 UI와 IHomeThemeRaw/IHomeTheme 타입 추가
- 홈 헤더에 HOME 타이틀과 메뉴 버튼 표시를 지원하도록 MobileHeader/MobileLayout 확장
- Axios 인터셉터의 토큰 재발급 API를 /api/auth/reissue로 변경
- 사용되지 않는 AuthService.refresh 메서드를 제거해 재발급 흐름을 인터셉터 중심으로 정리
- 검증: npm run lint