### PR TITLE
테마 커뮤니티 Refactoring (#64)

### DIFF
--- a/docs/frontend-handover.md
+++ b/docs/frontend-handover.md
@@ -35,7 +35,7 @@
 4. `src/main.tsx` -> `src/routes/AppRoutes.tsx` -> `src/layouts/MobileLayout.tsx` 순서로 앱 뼈대를 봅니다.
 5. `src/services/api/ApiClient.ts`에서 인증/refresh 흐름을 확인합니다.
 6. `src/constants/queryKeys.ts`와 `src/services/hooks`에서 서버 상태 관리 방식을 봅니다.
-7. 테마 커뮤니티 흐름을 목록 -> 상세 -> 작성 -> 수정 순서로 따라갑니다. 디자인 커뮤니티는 같은 패턴의 변형입니다.
+7. 커뮤니티 흐름을 `/community/theme` 테마 탭과 `/community/design` 디자인 에셋 탭 기준으로 따라갑니다.
 
 <a id="overview"></a>
 
@@ -47,7 +47,8 @@
 
 - 로그인, 회원가입, 카카오 로그인
 - 홈에서 인기 테마와 저장 테마 확인
-- 테마/디자인 커뮤니티 목록, 상세, 작성, 수정, 삭제
+- 커뮤니티의 테마/디자인 에셋 게시글 목록, 상세, 작성, 수정, 삭제
+- 알림 탭
 - 게시글 좋아요, 북마크, 댓글, 댓글 좋아요
 - 마이페이지 프로필 수정, 내가 올린 글, 저장한 글, 커스텀 컴포넌트 확인
 
@@ -138,16 +139,18 @@ createRoot(document.getElementById("root")!).render(
 | `/signup` | `AuthLayout` | 공개 | 회원가입 |
 | `/auth/kakao/callback` | 없음 | 공개 | 카카오 콜백 |
 | `/` | `MobileLayout` | 보호 | 홈 |
-| `/community` | `MobileLayout` | 보호 | 테마 목록 |
-| `/community/write` | `MobileLayout` | 보호 | 테마 선택 |
-| `/community/write/post` | `MobileLayout` | 보호 | 테마 글 작성 |
-| `/community/edit/:boardId` | `MobileLayout` | 보호 | 테마 글 수정 |
-| `/community/:boardId` | `MobileLayout` | 보호 | 테마 상세 |
-| `/design` | `MobileLayout` | 보호 | 디자인 목록 |
-| `/design/write` | `MobileLayout` | 보호 | 디자인 선택 |
-| `/design/write/post` | `MobileLayout` | 보호 | 디자인 글 작성 |
-| `/design/edit/:boardId` | `MobileLayout` | 보호 | 디자인 글 수정 |
-| `/design/:boardId` | `MobileLayout` | 보호 | 디자인 상세 |
+| `/community` | `MobileLayout` | 보호 | `/community/theme`로 redirect |
+| `/community/theme` | `MobileLayout` | 보호 | 커뮤니티 테마 탭 |
+| `/community/design` | `MobileLayout` | 보호 | 커뮤니티 디자인 에셋 탭 |
+| `/community/theme/write/select` | `MobileLayout` | 보호 | 테마 선택 |
+| `/community/theme/write` | `MobileLayout` | 보호 | 테마 글 작성 |
+| `/community/theme/edit/:boardId` | `MobileLayout` | 보호 | 테마 글 수정 |
+| `/community/theme/:boardId` | `MobileLayout` | 보호 | 테마 상세 |
+| `/community/design/write/select` | `MobileLayout` | 보호 | 디자인 에셋 선택 |
+| `/community/design/write` | `MobileLayout` | 보호 | 디자인 에셋 글 작성 |
+| `/community/design/edit/:boardId` | `MobileLayout` | 보호 | 디자인 에셋 글 수정 |
+| `/community/design/:boardId` | `MobileLayout` | 보호 | 디자인 에셋 상세 |
+| `/notify` | `MobileLayout` | 보호 | 알림 |
 | `/mypage` | `MobileLayout` | 보호 | 마이페이지 |
 
 `ProtectedRoutes`는 `useAuthStore(state => state.isAuthenticated)`만 보고 접근을 허용합니다. 실패하면 `/login`으로 redirect합니다.
@@ -156,13 +159,14 @@ createRoot(document.getElementById("root")!).render(
 
 - `AuthLayout`: 로그인/회원가입용 모바일 프레임
 - `MobileLayout`: 인증 후 앱 프레임, header, scroll container, bottom tab 담당
-- `BottomTabBar`: Home, 게시글, 디자인, 마이 탭
+- `BottomTabBar`: Home, 게시글, 알림, 마이 탭
 - `MobileHeader`: 로고, 제목, 뒤로가기, 메뉴 버튼
 
 `MobileLayout` 주의점:
 
 - `id="phone-root"`가 프레임 루트입니다. 댓글 포털 등에서 기준으로 사용할 수 있습니다.
 - header title, bottom tab active, detail page 여부가 pathname 조건으로 계산됩니다.
+- `/community/theme`, `/community/design`은 커뮤니티 탭 목록 경로라 뒤로가기 버튼을 숨깁니다.
 - 새 route를 추가하면 `MobileLayout`의 route flag도 같이 확인해야 합니다.
 
 <a id="structure-convention"></a>
@@ -190,9 +194,9 @@ src/
 
 - `auth`: 로그인/회원가입 폼
 - `common`: Button, Text, TabMenu, Alert, Confirm, ImageSlider, MoreMenu
-- `community`: 테마/디자인 커뮤니티 공통 UI
+- `community`: 커뮤니티 공통 UI
 - `community/theme`: 테마 전용 카드, 프리뷰, 탭
-- `community/design`: 디자인 전용 카드, 프리뷰, 탭
+- `community/design`: 디자인 에셋 전용 카드, 프리뷰, 탭
 - `home`: 홈 탭/그리드/준비중 UI
 - `icons`: SVG 아이콘
 - `mypage`: 프로필, 마이페이지 탭/카드
@@ -378,7 +382,7 @@ API service:
 | `AuthService` | 로그인, 회원가입, 로그아웃, 카카오 URL, dev auth |
 | `UserService` | 내 정보, 내가 올린 글, 북마크 글, 커스텀 컴포넌트, 프로필 수정 |
 | `ThemeService` | 테마 목록/상세/유저 테마/인기/저장/작성/수정/삭제 |
-| `DesignService` | 디자인 목록/상세/유저 디자인/작성/수정/삭제 |
+| `DesignService` | 디자인 에셋 목록/상세/유저 디자인/작성/수정/삭제 |
 | `BoardInteractionService` | 좋아요, 북마크, 댓글 CRUD, 댓글 좋아요 |
 
 Query key는 `src/constants/queryKeys.ts`의 `QUERY_KEYS`를 사용합니다.
@@ -433,7 +437,7 @@ QUERY_KEYS.userDesignComponents(userEmail)
 
 ## 9. 주요 도메인 흐름
 
-### 테마 커뮤니티
+### 커뮤니티 - 테마 탭
 
 주요 파일:
 
@@ -454,9 +458,10 @@ QUERY_KEYS.userDesignComponents(userEmail)
 
 흐름:
 
-- 목록은 `useThemeBoards()`와 `ActivityTab`을 사용합니다. page size는 20입니다.
-- 상세는 URL의 `boardId`를 `pinned_post_id`로 사용하고 `BoardSwipeDetailView`가 세로 스와이프를 담당합니다.
-- 작성은 `/community/write`에서 테마 선택 후 router state로 `/community/write/post`에 전달합니다.
+- `/community`는 `/community/theme`로 redirect됩니다.
+- 테마 탭 목록은 `/community/theme`에서 `useThemeBoards()`와 `ActivityTab`을 사용합니다. page size는 20입니다.
+- 상세는 `/community/theme/:boardId`에서 URL의 `boardId`를 `pinned_post_id`로 사용하고 `BoardSwipeDetailView`가 세로 스와이프를 담당합니다.
+- 작성은 `/community/theme/write/select`에서 테마 선택 후 router state로 `/community/theme/write`에 전달합니다.
 - 작성 submit은 `FormData`에 `board_info` JSON blob과 선택된 `preview_image`를 넣습니다.
 - 수정은 router state의 `board`로 form을 초기화합니다. state가 없으면 `navigate(-1)`합니다.
 
@@ -468,11 +473,12 @@ QUERY_KEYS.userDesignComponents(userEmail)
 - `publicFlag`
 - `post_tags`
 
-### 디자인 커뮤니티
+### 커뮤니티 - 디자인 에셋 탭
 
 주요 파일:
 
-- 목록: `src/pages/design-community/List.tsx`
+- 목록 컨테이너: `src/pages/theme-community/List.tsx`
+- 목록 UI: `src/components/community/design/tab/DesignActivityTab.tsx`
 - 상세: `src/pages/design-community/Detail.tsx`
 - 선택: `src/pages/design-community/BoardDesignSelect.tsx`
 - 작성: `src/pages/design-community/BoardDesignWrite.tsx`
@@ -487,7 +493,24 @@ QUERY_KEYS.userDesignComponents(userEmail)
 - `useDesignBoardEdit`
 - `useDeleteDesignBoard`
 
-테마 커뮤니티와 구조가 거의 같습니다. 차이는 선택 대상이 디자인 컴포넌트이고, 작성 payload에는 `designComponentId`가 들어가며, 수정 API는 `PATCH /api/design-boards/{postId}`입니다. 테마 수정은 `PUT /api/theme-boards/{postId}`입니다.
+디자인 에셋 탭은 `/community/design`에서 렌더링됩니다. 탭 클릭은 URL을 바꾸므로 새로고침해도 선택 탭이 유지됩니다. 작성/상세/수정 경로는 `/community/design/write/select`, `/community/design/write`, `/community/design/:boardId`, `/community/design/edit/:boardId`입니다.
+
+테마 탭과 구조가 거의 같습니다. 차이는 선택 대상이 디자인 컴포넌트이고, 작성 payload에는 `designComponentId`가 들어가며, 수정 API는 `PATCH /api/design-boards/{postId}`입니다. 테마 수정은 `PUT /api/theme-boards/{postId}`입니다.
+
+디자인 에셋 UI 진입은 `/community/design` 하위 경로만 사용합니다.
+
+### 알림
+
+주요 파일:
+
+- 화면: `src/pages/notification/Notification.tsx`
+- 하단 탭: `src/layouts/BottomTabBar.tsx`
+- 헤더/활성 상태: `src/layouts/MobileLayout.tsx`
+
+흐름:
+
+- 하단 알림 탭은 `/notify`로 이동합니다.
+- 현재 알림 API 연결은 없고, 빈 상태 문구를 보여줍니다.
 
 ### 공통 상세 카드와 작성 폼
 
@@ -637,9 +660,10 @@ npm run build
 
 - 로그인/회원가입/카카오 콜백
 - 홈 탭 전환, 인기/저장 테마 무한 스크롤
-- 테마 목록, 상세, 세로 스와이프, 좋아요, 북마크, 댓글
+- 커뮤니티 테마 탭(`/community/theme`) 목록, 상세, 세로 스와이프, 좋아요, 북마크, 댓글
 - 테마 글 작성, 수정, 삭제
-- 디자인 목록, 상세, 작성, 수정, 삭제
+- 커뮤니티 디자인 에셋 탭(`/community/design`) 목록, 상세, 작성, 수정, 삭제
+- 알림 탭(`/notify`) 진입과 하단 탭 활성 상태
 - 마이페이지 프로필 이미지/이름 수정
 - 내가 올린 글, 저장한 글, 커스텀 컴포넌트 탭
 - 저장글에서 북마크 해제 시 목록 제거
@@ -678,10 +702,11 @@ npm run build
 4. `src/services/api/ApiClient.ts`: Axios와 refresh 흐름 확인
 5. `src/stores/authStore.ts`: 인증 상태 모델 확인
 6. `src/constants/queryKeys.ts`: 캐시 key 규칙 확인
-7. `src/pages/theme-community/*`: 테마 목록/상세/작성/수정 흐름 확인
-8. `src/pages/design-community/*`: 테마와의 차이 확인
-9. `src/pages/mypage/MyPage.tsx`: 프로필과 탭 구조 확인
-10. `src/components/community/*`: 공통 상세/작성 컴포넌트 확인
+7. `src/pages/theme-community/List.tsx`: 커뮤니티 탭 URL(`/community/theme`, `/community/design`) 확인
+8. `src/pages/theme-community/*`: 테마 상세/작성/수정 흐름 확인
+9. `src/pages/design-community/*`: 디자인 에셋 상세/작성/수정 흐름 확인
+10. `src/pages/mypage/MyPage.tsx`: 프로필과 탭 구조 확인
+11. `src/components/community/*`: 공통 상세/작성 컴포넌트 확인
 
 <a id="file-map"></a>
 
@@ -694,13 +719,15 @@ npm run build
 | 보호 라우트 | `src/routes/ProtectedRoutes.tsx` |
 | 모바일 레이아웃 | `src/layouts/MobileLayout.tsx` |
 | 하단 탭 | `src/layouts/BottomTabBar.tsx` |
+| 알림 화면 | `src/pages/notification/Notification.tsx` |
 | API client | `src/services/api/ApiClient.ts` |
 | Query key | `src/constants/queryKeys.ts` |
 | 인증 store | `src/stores/authStore.ts` |
+| 커뮤니티 탭 목록 | `src/pages/theme-community/List.tsx` |
 | 테마 목록 hook | `src/services/hooks/theme/useThemeBoards.ts` |
 | 테마 상세 hook | `src/services/hooks/theme/useThemeBoardDetails.ts` |
-| 디자인 목록 hook | `src/services/hooks/design/useDesignBoards.ts` |
-| 디자인 상세 hook | `src/services/hooks/design/useDesignBoardDetails.ts` |
+| 디자인 에셋 목록 hook | `src/services/hooks/design/useDesignBoards.ts` |
+| 디자인 에셋 상세 hook | `src/services/hooks/design/useDesignBoardDetails.ts` |
 | 공통 상세 카드 | `src/components/community/BoardDetailCard.tsx` |
 | 공통 작성 폼 | `src/components/community/BoardWriteForm.tsx` |
 | 세로 스와이프 상세 | `src/components/community/BoardSwipeDetailView.tsx` |

--- a/docs/frontend-handover.md
+++ b/docs/frontend-handover.md
@@ -442,6 +442,7 @@ QUERY_KEYS.userDesignComponents(userEmail)
 주요 파일:
 
 - 목록: `src/pages/theme-community/List.tsx`
+- 공통 탭: `src/components/community/CommunityTabs.tsx`
 - 상세: `src/pages/theme-community/Detail.tsx`
 - 선택: `src/pages/theme-community/BoardThemeSelect.tsx`
 - 작성: `src/pages/theme-community/BoardWrite.tsx`
@@ -477,7 +478,8 @@ QUERY_KEYS.userDesignComponents(userEmail)
 
 주요 파일:
 
-- 목록 컨테이너: `src/pages/theme-community/List.tsx`
+- 목록: `src/pages/design-community/List.tsx`
+- 공통 탭: `src/components/community/CommunityTabs.tsx`
 - 목록 UI: `src/components/community/design/tab/DesignActivityTab.tsx`
 - 상세: `src/pages/design-community/Detail.tsx`
 - 선택: `src/pages/design-community/BoardDesignSelect.tsx`
@@ -702,7 +704,7 @@ npm run build
 4. `src/services/api/ApiClient.ts`: Axios와 refresh 흐름 확인
 5. `src/stores/authStore.ts`: 인증 상태 모델 확인
 6. `src/constants/queryKeys.ts`: 캐시 key 규칙 확인
-7. `src/pages/theme-community/List.tsx`: 커뮤니티 탭 URL(`/community/theme`, `/community/design`) 확인
+7. `src/pages/theme-community/List.tsx`, `src/pages/design-community/List.tsx`: 커뮤니티 탭 URL(`/community/theme`, `/community/design`) 확인
 8. `src/pages/theme-community/*`: 테마 상세/작성/수정 흐름 확인
 9. `src/pages/design-community/*`: 디자인 에셋 상세/작성/수정 흐름 확인
 10. `src/pages/mypage/MyPage.tsx`: 프로필과 탭 구조 확인
@@ -723,7 +725,9 @@ npm run build
 | API client | `src/services/api/ApiClient.ts` |
 | Query key | `src/constants/queryKeys.ts` |
 | 인증 store | `src/stores/authStore.ts` |
-| 커뮤니티 탭 목록 | `src/pages/theme-community/List.tsx` |
+| 커뮤니티 공통 탭 | `src/components/community/CommunityTabs.tsx` |
+| 테마 탭 목록 | `src/pages/theme-community/List.tsx` |
+| 디자인 에셋 탭 목록 | `src/pages/design-community/List.tsx` |
 | 테마 목록 hook | `src/services/hooks/theme/useThemeBoards.ts` |
 | 테마 상세 hook | `src/services/hooks/theme/useThemeBoardDetails.ts` |
 | 디자인 에셋 목록 hook | `src/services/hooks/design/useDesignBoards.ts` |

--- a/docs/frontend-handover.md
+++ b/docs/frontend-handover.md
@@ -165,7 +165,7 @@ createRoot(document.getElementById("root")!).render(
 `MobileLayout` 주의점:
 
 - `id="phone-root"`가 프레임 루트입니다. 댓글 포털 등에서 기준으로 사용할 수 있습니다.
-- header title, bottom tab active, detail page 여부가 pathname 조건으로 계산됩니다.
+- header title, bottom tab active, detail page 여부가 `MobileLayout.tsx`의 route helper로 계산됩니다.
 - `/community/theme`, `/community/design`은 커뮤니티 탭 목록 경로라 뒤로가기 버튼을 숨깁니다.
 - 새 route를 추가하면 `MobileLayout`의 route flag도 같이 확인해야 합니다.
 
@@ -675,7 +675,7 @@ npm run build
 우선순위 높은 주의점:
 
 - 일부 한글 문자열/주석이 깨져 보입니다. 특히 `MobileLayout.tsx`, `BottomTabBar.tsx`, `MyPage.tsx`, `ApiClient.ts`, `DesignService.ts`, `index.css`를 확인해야 합니다.
-- `MobileLayout`의 route 판별은 pathname 조건 기반입니다. route 추가 시 같이 수정해야 합니다.
+- `MobileLayout`의 route 판별은 route helper 기반입니다. route 추가 시 helper 조건도 같이 확인해야 합니다.
 - `DesignService.ts`에는 API endpoint 확인 필요 주석이 남아 있습니다.
 - `HomeThemeGrid`가 직접 data fetching을 합니다. 원칙상 Screen으로 올릴 수 있지만 현재 구조도 기능상 문제는 없습니다.
 - `useBoardWriteForm`의 blob URL unmount cleanup은 아직 없습니다.

--- a/src/components/community/CommunityTabs.tsx
+++ b/src/components/community/CommunityTabs.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import TabMenu from '../common/TabMenu';
+import type { CommunityTabId } from '../../types/community/common';
+
+const TABS: { id: CommunityTabId; label: string }[] = [
+  { id: 'theme', label: '테마' },
+  { id: 'design', label: '디자인 에셋' },
+];
+
+interface ICommunityTabsProps {
+  activeTab: CommunityTabId;
+}
+
+export default function CommunityTabs({ activeTab }: ICommunityTabsProps) {
+  const navigate = useNavigate();
+
+  const handleTabChange = (tabId: CommunityTabId) => {
+    navigate(tabId === 'theme' ? '/community/theme' : '/community/design');
+  };
+
+  return <TabMenu tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />;
+}

--- a/src/components/community/design/DesignBoardGridItem.tsx
+++ b/src/components/community/design/DesignBoardGridItem.tsx
@@ -8,7 +8,7 @@ interface IDesignBoardGridItemProps {
 export default function DesignBoardGridItem({ item }: IDesignBoardGridItemProps) {
   return (
     <Link
-      to={`/design/${item.boardId}`}
+      to={`/community/design/${item.boardId}`}
       className="block h-[120px] overflow-hidden rounded-[2px] bg-secondary-100"
       aria-label={`${item.title} 상세 페이지로 이동`}
     >

--- a/src/components/community/design/DesignDetailCard.tsx
+++ b/src/components/community/design/DesignDetailCard.tsx
@@ -18,7 +18,7 @@ export default function DesignDetailCard({ board, pinnedPostId }: IDesignDetailC
       board={board}
       downloadLabel="디자인 다운로드"
       imageAlt="디자인 미리보기"
-      editPath={`/design/edit/${board.boardId}`}
+      editPath={`/community/design/edit/${board.boardId}`}
       preferQueryKey={QUERY_KEYS.designBoardDetails(pinnedPostId)}
       deleteBoard={deleteBoard}
     />

--- a/src/components/community/design/tab/DesignActivityTab.tsx
+++ b/src/components/community/design/tab/DesignActivityTab.tsx
@@ -60,7 +60,7 @@ export default function DesignActivityTab({
         )}
       </main>
       <button
-        onClick={() => navigate('/community/design/write')}
+        onClick={() => navigate('/community/design/write/select')}
         className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-white shadow-sm"
       >
         <span className="mr-1 text-base leading-none">+</span>

--- a/src/components/community/design/tab/DesignActivityTab.tsx
+++ b/src/components/community/design/tab/DesignActivityTab.tsx
@@ -60,7 +60,7 @@ export default function DesignActivityTab({
         )}
       </main>
       <button
-        onClick={() => navigate('/design/write')}
+        onClick={() => navigate('/community/design/write')}
         className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-white shadow-sm"
       >
         <span className="mr-1 text-base leading-none">+</span>

--- a/src/components/community/index.ts
+++ b/src/components/community/index.ts
@@ -1,4 +1,5 @@
 export { default as SearchBar } from './SearchBar';
 export { default as CommentModal } from './CommentModal';
+export { default as CommunityTabs } from './CommunityTabs';
 export * from './theme';
 export * from './design';

--- a/src/components/community/theme/ThemeBoardGridItem.tsx
+++ b/src/components/community/theme/ThemeBoardGridItem.tsx
@@ -8,7 +8,7 @@ interface IThemeBoardGridItemProps {
 export default function ThemeBoardGridItem({ item }: IThemeBoardGridItemProps) {
   return (
     <Link
-      to={`/community/${item.boardId}`}
+      to={`/community/theme/${item.boardId}`}
       className="block h-[120px] overflow-hidden rounded-[2px] bg-secondary-100"
       aria-label={`${item.title} 상세 페이지로 이동`}
     >

--- a/src/components/community/theme/ThemeDetailCard.tsx
+++ b/src/components/community/theme/ThemeDetailCard.tsx
@@ -18,7 +18,7 @@ export default function ThemeDetailCard({ board, pinnedPostId }: IThemeDetailCar
       board={board}
       downloadLabel="테마 다운로드"
       imageAlt="테마 미리보기"
-      editPath={`/community/edit/${board.boardId}`}
+      editPath={`/community/theme/edit/${board.boardId}`}
       preferQueryKey={QUERY_KEYS.themeBoardDetails(pinnedPostId)}
       deleteBoard={deleteBoard}
     />

--- a/src/components/community/theme/tab/ActivityTab.tsx
+++ b/src/components/community/theme/tab/ActivityTab.tsx
@@ -59,7 +59,7 @@ export default function ActivityTab({
         )}
       </main>
       <button
-        onClick={() => navigate('/community/write')}
+        onClick={() => navigate('/community/theme/write/select')}
         className="absolute bottom-16 right-4 flex h-9 items-center rounded-full bg-primary px-4 text-white shadow-sm"
       >
         <span className="mr-1 text-base leading-none">+</span>

--- a/src/components/mypage/MyActivityCard.tsx
+++ b/src/components/mypage/MyActivityCard.tsx
@@ -28,7 +28,7 @@ export default function MyActivityCard({ post }: IMyActivityCardProps) {
   const isTheme = post.postType === 'THEME_BOARD';
   const editPath = isTheme
     ? `/community/edit/${post.boardId}`
-    : `/design/edit/${post.boardId}`;
+    : `/community/design/edit/${post.boardId}`;
   const deleteBoard = isTheme ? deleteThemeBoard : deleteDesignBoard;
 
   const moreMenuItems: IMoreMenuItem[] = [

--- a/src/components/mypage/MyActivityCard.tsx
+++ b/src/components/mypage/MyActivityCard.tsx
@@ -27,7 +27,7 @@ export default function MyActivityCard({ post }: IMyActivityCardProps) {
 
   const isTheme = post.postType === 'THEME_BOARD';
   const editPath = isTheme
-    ? `/community/edit/${post.boardId}`
+    ? `/community/theme/edit/${post.boardId}`
     : `/community/design/edit/${post.boardId}`;
   const deleteBoard = isTheme ? deleteThemeBoard : deleteDesignBoard;
 

--- a/src/layouts/BottomTabBar.tsx
+++ b/src/layouts/BottomTabBar.tsx
@@ -63,7 +63,7 @@ export default function BottomTabBar({ isHome, isCommunity, isDesign, isMyPage }
   const bottomTabBarItems: IBottomTabItem[] = [
     { icon: HomeIcon, text: "홈", href: "/", isActive: isHome },
     { icon: CommunityIcon, text: "게시글", href: "/community", isActive: isCommunity },
-    { icon: NotifyIcon, text: "디자인", href: "/design", isActive: isDesign },
+    { icon: NotifyIcon, text: "알림", href: "/design", isActive: isDesign },
     { icon: ProfileIcon, text: "마이", href: "/mypage", isActive: isMyPage },
   ]
 

--- a/src/layouts/BottomTabBar.tsx
+++ b/src/layouts/BottomTabBar.tsx
@@ -15,7 +15,7 @@ import ProfileIcon from  '../components/icons/bottom-tab-menu/bottom-profile.svg
 interface IBottomTabBarProps {
   isHome: boolean
   isCommunity: boolean
-  isDesign: boolean
+  isNotification: boolean
   isMyPage: boolean
 }
 
@@ -59,11 +59,11 @@ function BottomTabBarItem({ icon, text, href, isActive = false }: IBottomTabItem
   );
 }
 
-export default function BottomTabBar({ isHome, isCommunity, isDesign, isMyPage }: IBottomTabBarProps) {
+export default function BottomTabBar({ isHome, isCommunity, isNotification, isMyPage }: IBottomTabBarProps) {
   const bottomTabBarItems: IBottomTabItem[] = [
     { icon: HomeIcon, text: "홈", href: "/", isActive: isHome },
     { icon: CommunityIcon, text: "게시글", href: "/community", isActive: isCommunity },
-    { icon: NotifyIcon, text: "알림", href: "/design", isActive: isDesign },
+    { icon: NotifyIcon, text: "알림", href: "/notify", isActive: isNotification },
     { icon: ProfileIcon, text: "마이", href: "/mypage", isActive: isMyPage },
   ]
 

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -17,7 +17,7 @@ export default function MobileLayout() {
   const isCommunityDetail: boolean = pathname.split('/').filter(Boolean).length >= 2 && isCommunity && !isBoardWrite && !isBoardEdit
   const isDesignDetail: boolean = pathname.split('/').filter(Boolean).length >= 2 && isDesign && !isDesignBoardWrite && !isDesignBoardEdit
   const hasHeader: boolean = isHome || isCommunity || isDesign || isMyPage
-  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "테마 커뮤니티" : isDesign ? "디자인 커뮤니티" : isMyPage ? "마이페이지" : "고정 헤더"
+  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "커뮤니티" : isDesign ? "디자인 커뮤니티" : isMyPage ? "마이페이지" : "고정 헤더"
 
   // 뒤로가기 버튼을 보여주어야 하는 경로인지 판별
   // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/6'의 경우 2로 봄)

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -10,20 +10,18 @@ export default function MobileLayout() {
   const isHome: boolean = pathname === "/"
   const isCommunity: boolean = pathname.startsWith("/community")
   const isCommunityList: boolean = pathname === "/community/theme" || pathname === "/community/design"
-  const isDesign: boolean = pathname.startsWith("/design")
   const isNotification: boolean = pathname === "/notify"
   const isMyPage: boolean = pathname.startsWith("/mypage")
-  const isBoardWrite: boolean = pathname.startsWith("/community/write")
-  const isDesignBoardWrite: boolean = pathname.startsWith("/design/write") || pathname.startsWith("/community/design/write")
-  const isBoardEdit: boolean = pathname.startsWith("/community/edit")
-  const isDesignBoardEdit: boolean = pathname.startsWith("/design/edit") || pathname.startsWith("/community/design/edit")
+  const isBoardWrite: boolean = pathname.startsWith("/community/theme/write")
+  const isDesignBoardWrite: boolean = pathname.startsWith("/community/design/write")
+  const isBoardEdit: boolean = pathname.startsWith("/community/theme/edit")
+  const isDesignBoardEdit: boolean = pathname.startsWith("/community/design/edit")
   const isCommunityDetail: boolean = pathSegments.length >= 2 && isCommunity && !isCommunityList && !isBoardWrite && !isBoardEdit && !isDesignBoardWrite && !isDesignBoardEdit
-  const isDesignDetail: boolean = pathSegments.length >= 2 && isDesign && !isDesignBoardWrite && !isDesignBoardEdit
-  const hasHeader: boolean = isHome || isCommunity || isDesign || isNotification || isMyPage
-  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "커뮤니티" : isNotification ? "알림" : isDesign ? "커뮤니티" : isMyPage ? "마이페이지" : "고정 헤더"
+  const hasHeader: boolean = isHome || isCommunity || isNotification || isMyPage
+  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "커뮤니티" : isNotification ? "알림" : isMyPage ? "마이페이지" : "고정 헤더"
 
   // 뒤로가기 버튼을 보여주어야 하는 경로인지 판별
-  // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/6'의 경우 2로 봄)
+  // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/theme/6'의 경우 3으로 봄)
   // 경로의 끝에 /가 올 경우 정확하게 처리하지 못할 수 있어 filter(Boolean)을 사용하여 빈 문자열을 제거
   const hasBackArrow: boolean = pathSegments.length >= 2 && !isCommunityList;
   const scrollToTop = useCallback(() => {
@@ -38,7 +36,7 @@ export default function MobileLayout() {
 
         <div
           ref={scrollContainerRef}
-          className={`scrollbar-hidden flex-1 overflow-y-auto ${isCommunityDetail || isDesignDetail ? "" : "pb-16"}`}
+          className={`scrollbar-hidden flex-1 overflow-y-auto ${isCommunityDetail ? "" : "pb-16"}`}
         >
           <Outlet context={outletContext} />
         </div>

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -6,23 +6,26 @@ import MobileHeader from "./MobileHeader";
 export default function MobileLayout() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { pathname } = useLocation()
+  const pathSegments = pathname.split('/').filter(Boolean);
   const isHome: boolean = pathname === "/"
   const isCommunity: boolean = pathname.startsWith("/community")
+  const isCommunityList: boolean = pathname === "/community/theme" || pathname === "/community/design"
   const isDesign: boolean = pathname.startsWith("/design")
+  const isNotification: boolean = pathname === "/notify"
   const isMyPage: boolean = pathname.startsWith("/mypage")
   const isBoardWrite: boolean = pathname.startsWith("/community/write")
-  const isDesignBoardWrite: boolean = pathname.startsWith("/design/write")
+  const isDesignBoardWrite: boolean = pathname.startsWith("/design/write") || pathname.startsWith("/community/design/write")
   const isBoardEdit: boolean = pathname.startsWith("/community/edit")
-  const isDesignBoardEdit: boolean = pathname.startsWith("/design/edit")
-  const isCommunityDetail: boolean = pathname.split('/').filter(Boolean).length >= 2 && isCommunity && !isBoardWrite && !isBoardEdit
-  const isDesignDetail: boolean = pathname.split('/').filter(Boolean).length >= 2 && isDesign && !isDesignBoardWrite && !isDesignBoardEdit
-  const hasHeader: boolean = isHome || isCommunity || isDesign || isMyPage
-  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "커뮤니티" : isDesign ? "디자인 커뮤니티" : isMyPage ? "마이페이지" : "고정 헤더"
+  const isDesignBoardEdit: boolean = pathname.startsWith("/design/edit") || pathname.startsWith("/community/design/edit")
+  const isCommunityDetail: boolean = pathSegments.length >= 2 && isCommunity && !isCommunityList && !isBoardWrite && !isBoardEdit && !isDesignBoardWrite && !isDesignBoardEdit
+  const isDesignDetail: boolean = pathSegments.length >= 2 && isDesign && !isDesignBoardWrite && !isDesignBoardEdit
+  const hasHeader: boolean = isHome || isCommunity || isDesign || isNotification || isMyPage
+  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "커뮤니티" : isNotification ? "알림" : isDesign ? "커뮤니티" : isMyPage ? "마이페이지" : "고정 헤더"
 
   // 뒤로가기 버튼을 보여주어야 하는 경로인지 판별
   // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/6'의 경우 2로 봄)
   // 경로의 끝에 /가 올 경우 정확하게 처리하지 못할 수 있어 filter(Boolean)을 사용하여 빈 문자열을 제거
-  const hasBackArrow: boolean = pathname.split('/').filter(Boolean).length >= 2;
+  const hasBackArrow: boolean = pathSegments.length >= 2 && !isCommunityList;
   const scrollToTop = useCallback(() => {
     scrollContainerRef.current?.scrollTo({ top: 0, left: 0, behavior: "auto" });
   }, []);
@@ -40,7 +43,7 @@ export default function MobileLayout() {
           <Outlet context={outletContext} />
         </div>
 
-        <BottomTabBar isHome={isHome} isCommunity={isCommunity} isDesign={isDesign} isMyPage={pathname.startsWith("/mypage")} />
+        <BottomTabBar isHome={isHome} isCommunity={isCommunity} isNotification={isNotification} isMyPage={pathname.startsWith("/mypage")} />
       </div>
     </div>
   )

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -3,22 +3,41 @@ import { useCallback, useMemo, useRef } from "react";
 import BottomTabBar from "./BottomTabBar";
 import MobileHeader from "./MobileHeader";
 
+const COMMUNITY_LIST_PATHS = ["/community/theme", "/community/design"];
+const COMMUNITY_WRITE_PATH_PATTERN = /^\/community\/(theme|design)\/write(\/select)?$/;
+const COMMUNITY_EDIT_PATH_PATTERN = /^\/community\/(theme|design)\/edit\/[^/]+$/;
+const COMMUNITY_DETAIL_PATH_PATTERN = /^\/community\/(theme|design)\/\d+$/;
+
+function isCommunityListPath(pathname: string) {
+  return COMMUNITY_LIST_PATHS.includes(pathname);
+}
+
+function isCommunityWritePath(pathname: string) {
+  return COMMUNITY_WRITE_PATH_PATTERN.test(pathname);
+}
+
+function isCommunityEditPath(pathname: string) {
+  return COMMUNITY_EDIT_PATH_PATTERN.test(pathname);
+}
+
+function isCommunityDetailPath(pathname: string) {
+  return COMMUNITY_DETAIL_PATH_PATTERN.test(pathname);
+}
+
 export default function MobileLayout() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { pathname } = useLocation()
   const pathSegments = pathname.split('/').filter(Boolean);
   const isHome: boolean = pathname === "/"
   const isCommunity: boolean = pathname.startsWith("/community")
-  const isCommunityList: boolean = pathname === "/community/theme" || pathname === "/community/design"
+  const isCommunityList: boolean = isCommunityListPath(pathname)
   const isNotification: boolean = pathname === "/notify"
   const isMyPage: boolean = pathname.startsWith("/mypage")
-  const isBoardWrite: boolean = pathname.startsWith("/community/theme/write")
-  const isDesignBoardWrite: boolean = pathname.startsWith("/community/design/write")
-  const isBoardEdit: boolean = pathname.startsWith("/community/theme/edit")
-  const isDesignBoardEdit: boolean = pathname.startsWith("/community/design/edit")
-  const isCommunityDetail: boolean = pathSegments.length >= 2 && isCommunity && !isCommunityList && !isBoardWrite && !isBoardEdit && !isDesignBoardWrite && !isDesignBoardEdit
+  const isCommunityWrite: boolean = isCommunityWritePath(pathname)
+  const isCommunityEdit: boolean = isCommunityEditPath(pathname)
+  const isCommunityDetail: boolean = isCommunityDetailPath(pathname)
   const hasHeader: boolean = isHome || isCommunity || isNotification || isMyPage
-  const headerTitle: string = isBoardWrite || isDesignBoardWrite ? "글 작성" : isBoardEdit || isDesignBoardEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "커뮤니티" : isNotification ? "알림" : isMyPage ? "마이페이지" : "고정 헤더"
+  const headerTitle: string = isCommunityWrite ? "글 작성" : isCommunityEdit ? "글 수정" : isHome ? "HOME" : isCommunity ? "커뮤니티" : isNotification ? "알림" : isMyPage ? "마이페이지" : "고정 헤더"
 
   // 뒤로가기 버튼을 보여주어야 하는 경로인지 판별
   // 현재 기준은 depth가 2이상인 경우 ('/'의 경우 0으로 보고, '/community'의 경우 1로 보고, '/community/theme/6'의 경우 3으로 봄)

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -60,7 +60,7 @@ export default function MobileLayout() {
           <Outlet context={outletContext} />
         </div>
 
-        <BottomTabBar isHome={isHome} isCommunity={isCommunity} isNotification={isNotification} isMyPage={pathname.startsWith("/mypage")} />
+        <BottomTabBar isHome={isHome} isCommunity={isCommunity} isNotification={isNotification} isMyPage={isMyPage} />
       </div>
     </div>
   )

--- a/src/pages/design-community/BoardDesignSelect.tsx
+++ b/src/pages/design-community/BoardDesignSelect.tsx
@@ -20,7 +20,7 @@ export default function BoardDesignSelect() {
       renderItem={(component, isSelected, onSelect) => (
         <DesignSelectItem component={component} isSelected={isSelected} onSelect={onSelect} />
       )}
-      onConfirm={(component) => navigate('/design/write/post', { state: { selectedComponent: component } })}
+      onConfirm={(component) => navigate('/community/design/write/post', { state: { selectedComponent: component } })}
     />
   );
 }

--- a/src/pages/design-community/BoardDesignSelect.tsx
+++ b/src/pages/design-community/BoardDesignSelect.tsx
@@ -20,7 +20,7 @@ export default function BoardDesignSelect() {
       renderItem={(component, isSelected, onSelect) => (
         <DesignSelectItem component={component} isSelected={isSelected} onSelect={onSelect} />
       )}
-      onConfirm={(component) => navigate('/community/design/write/post', { state: { selectedComponent: component } })}
+      onConfirm={(component) => navigate('/community/design/write', { state: { selectedComponent: component } })}
     />
   );
 }

--- a/src/pages/design-community/BoardDesignWrite.tsx
+++ b/src/pages/design-community/BoardDesignWrite.tsx
@@ -16,7 +16,7 @@ export default function BoardDesignWrite() {
 
   useEffect(() => {
     if (!state?.selectedComponent) {
-      navigate('/design/write', { replace: true });
+      navigate('/community/design/write', { replace: true });
     }
   }, [state, navigate]);
 

--- a/src/pages/design-community/BoardDesignWrite.tsx
+++ b/src/pages/design-community/BoardDesignWrite.tsx
@@ -16,7 +16,7 @@ export default function BoardDesignWrite() {
 
   useEffect(() => {
     if (!state?.selectedComponent) {
-      navigate('/community/design/write', { replace: true });
+      navigate('/community/design/write/select', { replace: true });
     }
   }, [state, navigate]);
 

--- a/src/pages/design-community/List.tsx
+++ b/src/pages/design-community/List.tsx
@@ -1,34 +1,15 @@
-import { useState } from 'react';
 import { DesignActivityTab } from "../../components/community/design";
-import { KeywordTab } from "../../components/community";
-import TabMenu from "../../components/common/TabMenu";
-import type { TabId } from "../../types/community/theme";
+import { CommunityTabs } from "../../components/community";
 import { useDesignBoards } from "../../services/hooks/design/useDesignBoards";
 
-const TABS: { id: TabId; label: string }[] = [
-  { id: 'activity', label: '활동' },
-  { id: 'keyword', label: '키워드' },
-];
-
 export default function List() {
-  const [activeTab, setActiveTab] = useState<TabId>('activity');
-  const { boards, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useDesignBoards();
+  const designBoards = useDesignBoards();
 
   return (
     <div>
-      <TabMenu tabs={TABS} activeTab={activeTab} onTabChange={setActiveTab} />
+      <CommunityTabs activeTab="design" />
       <div className="flex-1">
-        {activeTab === 'activity' && (
-          <DesignActivityTab
-            boards={boards}
-            isLoading={isLoading}
-            isError={isError}
-            fetchNextPage={fetchNextPage}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-          />
-        )}
-        {activeTab === 'keyword' && <KeywordTab />}
+        <DesignActivityTab {...designBoards} />
       </div>
     </div>
   );

--- a/src/pages/notification/Notification.tsx
+++ b/src/pages/notification/Notification.tsx
@@ -1,0 +1,11 @@
+import Text from '../../components/common/Text';
+
+export default function Notification() {
+  return (
+    <main className="flex min-h-[360px] items-center justify-center px-4">
+      <Text variant="REGULAR_15" className="text-secondary-500">
+        아직 알림이 없습니다.
+      </Text>
+    </main>
+  );
+}

--- a/src/pages/theme-community/BoardThemeSelect.tsx
+++ b/src/pages/theme-community/BoardThemeSelect.tsx
@@ -20,7 +20,7 @@ export default function BoardThemeSelect() {
       renderItem={(theme, isSelected, onSelect) => (
         <ThemeSelectItem theme={theme} isSelected={isSelected} onSelect={onSelect} />
       )}
-      onConfirm={(theme) => navigate('/community/write/post', { state: { selectedTheme: theme } })}
+      onConfirm={(theme) => navigate('/community/theme/write', { state: { selectedTheme: theme } })}
     />
   );
 }

--- a/src/pages/theme-community/BoardWrite.tsx
+++ b/src/pages/theme-community/BoardWrite.tsx
@@ -16,7 +16,7 @@ export default function BoardWrite() {
 
   useEffect(() => {
     if (!state?.selectedTheme) {
-      navigate('/community/write', { replace: true });
+      navigate('/community/theme/write/select', { replace: true });
     }
   }, [state, navigate]);
 

--- a/src/pages/theme-community/List.tsx
+++ b/src/pages/theme-community/List.tsx
@@ -5,8 +5,8 @@ import type { TabId } from "../../types/community/theme";
 import { useThemeBoards } from "../../services/hooks/theme/useThemeBoards";
 
 const TABS: { id: TabId; label: string }[] = [
-  { id: 'activity', label: '활동' },
-  { id: 'keyword', label: '키워드' },
+  { id: 'activity', label: '테마' },
+  { id: 'keyword', label: '디자인 에셋' },
 ];
 
 export default function List() {

--- a/src/pages/theme-community/List.tsx
+++ b/src/pages/theme-community/List.tsx
@@ -1,43 +1,15 @@
-import { useLocation, useNavigate } from 'react-router-dom';
-import { ActivityTab } from "../../components/community";
-import { DesignActivityTab } from "../../components/community/design";
-import TabMenu from "../../components/common/TabMenu";
-import type { TabId } from "../../types/community/theme";
+import { ActivityTab, CommunityTabs } from "../../components/community";
 import { useThemeBoards } from "../../services/hooks/theme/useThemeBoards";
-import { useDesignBoards } from "../../services/hooks/design/useDesignBoards";
-
-const TABS: { id: TabId; label: string }[] = [
-  { id: 'activity', label: '테마' },
-  { id: 'keyword', label: '디자인 에셋' },
-];
 
 export default function List() {
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
-  const activeTab: TabId = pathname === '/community/design' ? 'keyword' : 'activity';
-  const handleTabChange = (tabId: TabId) => {
-    navigate(tabId === 'activity' ? '/community/theme' : '/community/design');
-  };
+  const themeBoards = useThemeBoards();
 
   return (
     <div>
-      <TabMenu tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />
+      <CommunityTabs activeTab="theme" />
       <div className="flex-1">
-        {activeTab === 'activity' && <ThemeTabContent />}
-        {activeTab === 'keyword' && <DesignAssetTabContent />}
+        <ActivityTab {...themeBoards} />
       </div>
     </div>
   );
-}
-
-function ThemeTabContent() {
-  const themeBoards = useThemeBoards();
-
-  return <ActivityTab {...themeBoards} />;
-}
-
-function DesignAssetTabContent() {
-  const designBoards = useDesignBoards();
-
-  return <DesignActivityTab {...designBoards} />;
 }

--- a/src/pages/theme-community/List.tsx
+++ b/src/pages/theme-community/List.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
-import { ActivityTab, KeywordTab } from "../../components/community";
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ActivityTab } from "../../components/community";
+import { DesignActivityTab } from "../../components/community/design";
 import TabMenu from "../../components/common/TabMenu";
 import type { TabId } from "../../types/community/theme";
 import { useThemeBoards } from "../../services/hooks/theme/useThemeBoards";
+import { useDesignBoards } from "../../services/hooks/design/useDesignBoards";
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'activity', label: '테마' },
@@ -10,25 +12,32 @@ const TABS: { id: TabId; label: string }[] = [
 ];
 
 export default function List() {
-  const [activeTab, setActiveTab] = useState<TabId>('activity');
-  const { boards, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useThemeBoards();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const activeTab: TabId = pathname === '/community/design' ? 'keyword' : 'activity';
+  const handleTabChange = (tabId: TabId) => {
+    navigate(tabId === 'activity' ? '/community/theme' : '/community/design');
+  };
 
   return (
     <div>
-      <TabMenu tabs={TABS} activeTab={activeTab} onTabChange={setActiveTab} />
+      <TabMenu tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />
       <div className="flex-1">
-        {activeTab === 'activity' && (
-          <ActivityTab
-            boards={boards}
-            isLoading={isLoading}
-            isError={isError}
-            fetchNextPage={fetchNextPage}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-          />
-        )}
-        {activeTab === 'keyword' && <KeywordTab />}
+        {activeTab === 'activity' && <ThemeTabContent />}
+        {activeTab === 'keyword' && <DesignAssetTabContent />}
       </div>
     </div>
   );
+}
+
+function ThemeTabContent() {
+  const themeBoards = useThemeBoards();
+
+  return <ActivityTab {...themeBoards} />;
+}
+
+function DesignAssetTabContent() {
+  const designBoards = useDesignBoards();
+
+  return <DesignActivityTab {...designBoards} />;
 }

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -48,19 +48,15 @@ export default function AppRoutes() {
             <Route path="/community" element={<Navigate to="/community/theme" replace />} />
             <Route path="/community/theme" element={<ThemeCommunityList />} />
             <Route path="/community/design" element={<ThemeCommunityList />} />
-            <Route path="/community/write" element={<BoardThemeSelect />} />
-            <Route path="/community/write/post" element={<BoardWrite />} />
-            <Route path="/community/edit/:boardId" element={<BoardThemeEdit />} />
-            <Route path="/community/design/write" element={<BoardDesignSelect />} />
-            <Route path="/community/design/write/post" element={<BoardDesignWrite />} />
+            <Route path="/community/theme/write/select" element={<BoardThemeSelect />} />
+            <Route path="/community/theme/write" element={<BoardWrite />} />
+            <Route path="/community/theme/edit/:boardId" element={<BoardThemeEdit />} />
+            <Route path="/community/theme/:boardId" element={<ThemeCommunityDetail />} />
+            <Route path="/community/design/write/select" element={<BoardDesignSelect />} />
+            <Route path="/community/design/write" element={<BoardDesignWrite />} />
             <Route path="/community/design/edit/:boardId" element={<BoardDesignEdit />} />
             <Route path="/community/design/:boardId" element={<DesignCommunityDetail />} />
-            <Route path="/community/:boardId" element={<ThemeCommunityDetail />} />
             <Route path="/notify" element={<Notification />} />
-            <Route path="/design/write" element={<BoardDesignSelect />} />
-            <Route path="/design/write/post" element={<BoardDesignWrite />} />
-            <Route path="/design/edit/:boardId" element={<BoardDesignEdit />} />
-            <Route path="/design/:boardId" element={<DesignCommunityDetail />} />
             <Route path="/mypage" element={<MyPage />} />
           </Route>
         </Route>

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,8 +1,7 @@
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import Home from "../pages/home/Home.tsx";
 import ThemeCommunityList from "../pages/theme-community/List.tsx";
 import ThemeCommunityDetail from "../pages/theme-community/Detail.tsx";
-import DesignCommunityList from "../pages/design-community/List.tsx";
 import DesignCommunityDetail from "../pages/design-community/Detail.tsx";
 import BoardThemeSelect from "../pages/theme-community/BoardThemeSelect.tsx";
 import BoardWrite from "../pages/theme-community/BoardWrite.tsx";
@@ -10,6 +9,7 @@ import BoardDesignSelect from "../pages/design-community/BoardDesignSelect.tsx";
 import BoardDesignWrite from "../pages/design-community/BoardDesignWrite.tsx";
 import BoardThemeEdit from "../pages/theme-community/BoardThemeEdit.tsx";
 import BoardDesignEdit from "../pages/design-community/BoardDesignEdit.tsx";
+import Notification from "../pages/notification/Notification.tsx";
 import MyPage from "../pages/mypage/MyPage.tsx";
 import MobileLayout from "../layouts/MobileLayout.tsx";
 import AuthLayout from "../layouts/AuthLayout.tsx";
@@ -45,12 +45,18 @@ export default function AppRoutes() {
         <Route element={<ProtectedRoutes />}>
           <Route element={<MobileLayout />}>
             <Route path="/" element={<Home />} />
-            <Route path="/community" element={<ThemeCommunityList />} />
+            <Route path="/community" element={<Navigate to="/community/theme" replace />} />
+            <Route path="/community/theme" element={<ThemeCommunityList />} />
+            <Route path="/community/design" element={<ThemeCommunityList />} />
             <Route path="/community/write" element={<BoardThemeSelect />} />
             <Route path="/community/write/post" element={<BoardWrite />} />
             <Route path="/community/edit/:boardId" element={<BoardThemeEdit />} />
+            <Route path="/community/design/write" element={<BoardDesignSelect />} />
+            <Route path="/community/design/write/post" element={<BoardDesignWrite />} />
+            <Route path="/community/design/edit/:boardId" element={<BoardDesignEdit />} />
+            <Route path="/community/design/:boardId" element={<DesignCommunityDetail />} />
             <Route path="/community/:boardId" element={<ThemeCommunityDetail />} />
-            <Route path="/design" element={<DesignCommunityList />} />
+            <Route path="/notify" element={<Notification />} />
             <Route path="/design/write" element={<BoardDesignSelect />} />
             <Route path="/design/write/post" element={<BoardDesignWrite />} />
             <Route path="/design/edit/:boardId" element={<BoardDesignEdit />} />

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import Home from "../pages/home/Home.tsx";
 import ThemeCommunityList from "../pages/theme-community/List.tsx";
 import ThemeCommunityDetail from "../pages/theme-community/Detail.tsx";
+import DesignCommunityList from "../pages/design-community/List.tsx";
 import DesignCommunityDetail from "../pages/design-community/Detail.tsx";
 import BoardThemeSelect from "../pages/theme-community/BoardThemeSelect.tsx";
 import BoardWrite from "../pages/theme-community/BoardWrite.tsx";
@@ -47,7 +48,7 @@ export default function AppRoutes() {
             <Route path="/" element={<Home />} />
             <Route path="/community" element={<Navigate to="/community/theme" replace />} />
             <Route path="/community/theme" element={<ThemeCommunityList />} />
-            <Route path="/community/design" element={<ThemeCommunityList />} />
+            <Route path="/community/design" element={<DesignCommunityList />} />
             <Route path="/community/theme/write/select" element={<BoardThemeSelect />} />
             <Route path="/community/theme/write" element={<BoardWrite />} />
             <Route path="/community/theme/edit/:boardId" element={<BoardThemeEdit />} />

--- a/src/services/hooks/design/useDesignBoardEdit.ts
+++ b/src/services/hooks/design/useDesignBoardEdit.ts
@@ -25,7 +25,7 @@ export function useDesignBoardEdit(board: IDesignBoardDetail) {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.designBoardDetails() });
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.myUploadPosts() });
-        navigate(`/design/${board.boardId}`, { replace: true });
+        navigate(`/community/design/${board.boardId}`, { replace: true });
       },
     },
   );

--- a/src/services/hooks/design/useDesignBoardWrite.ts
+++ b/src/services/hooks/design/useDesignBoardWrite.ts
@@ -14,9 +14,10 @@ export function useDesignBoardWrite(selectedComponent: IUserDesignComponentRaw) 
   const { mutate, isPending } = usePostMutation<IDesignBoardCreateResponseRaw, FormData>(
     (formData) => DesignService.createDesignBoard(formData),
     {
-      onSuccess: () => {
+      onSuccess: (board) => {
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.userProfile() });
-        navigate('/design');
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.designBoards() });
+        navigate(`/community/design/${board.post_id}`);
       },
     },
   );

--- a/src/services/hooks/theme/useBoardWrite.ts
+++ b/src/services/hooks/theme/useBoardWrite.ts
@@ -16,7 +16,7 @@ export function useBoardWrite(selectedTheme: IUserTheme) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.userProfile() });
-        navigate('/community');
+        navigate('/community/theme');
       },
     },
   );

--- a/src/services/hooks/theme/useThemeBoardEdit.ts
+++ b/src/services/hooks/theme/useThemeBoardEdit.ts
@@ -25,7 +25,7 @@ export function useThemeBoardEdit(board: IThemeBoardDetail) {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.themeBoardDetails() });
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.myUploadPosts() });
-        navigate(`/community/${board.boardId}`, { replace: true });
+        navigate(`/community/theme/${board.boardId}`, { replace: true });
       },
     },
   );

--- a/src/types/community/common.ts
+++ b/src/types/community/common.ts
@@ -13,6 +13,8 @@ export interface ITag {
   tag_name: string;
 }
 
+export type CommunityTabId = 'theme' | 'design';
+
 // DesignDetailCard / ThemeDetailCard 공통 필드
 export interface IBoardDetailBase {
   boardId: number;

--- a/src/types/community/theme.ts
+++ b/src/types/community/theme.ts
@@ -80,12 +80,6 @@ export interface ICommentRaw {
   likes_count?: number;
 }
 
-export type TabId = 'activity' | 'keyword';
-export interface ITab {
-  id: TabId
-  label: string;
-}
-
 // GET /api/themes/user/{userEmail} 응답 항목 - 서버 원본 형식 (snake_case)
 export interface IUserThemeRaw {
   themeComponentId: number;


### PR DESCRIPTION
1. 기존 임시방편으로 사용하던 바텀메뉴 알림 아이콘 텍스트 변경(디자인 -> 알림)
    - match route 변경 (design -> notify)
    - 알림 화면으로 전환 (기존에 보여주던 디자인 에셋 게시글 목록 없앰)
2. 게시글 페이지 refactoring
    - 탭 메뉴 변경 (기존 활동/키워드 -> 테마/디자인 에셋 으로 변경)
    - match route 변경 (테마 탭: /community/theme, 디자인 에셋 탭: /community/design)
    - 바텀메뉴 게시글 route는 유지 (/community), 대신 /community 진입 시 /community/theme로 redirect 되도록 조정(테마 탭 기본)
    - 헤더 문구 변경 (테마 커뮤니티 -> 커뮤니티)