### PR TITLE
chore: 깃헙 이슈 템플릿 등록

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug Report
+description: 버그를 제보합니다.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 버그 설명
+      description: 어떤 문제가 발생했는지 설명해주세요.
+      placeholder: 예) 테마 목록 페이지에서 스크롤 시 카드가 겹쳐 보입니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 방법
+      description: 버그를 재현하는 순서를 작성해주세요.
+      placeholder: |
+        1. 테마 커뮤니티 페이지로 이동
+        2. 목록을 아래로 스크롤
+        3. 특정 카드 클릭
+        4. 오류 확인
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 기대 동작
+      description: 원래 어떻게 동작해야 하나요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 실제 동작
+      description: 실제로 어떤 동작이 발생했나요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 환경
+      description: 사용 환경을 작성해주세요.
+      value: |
+        - OS:
+        - Browser:
+        - Device:
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: 스크린샷
+      description: 가능하다면 문제 화면을 첨부해주세요.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,42 @@
+name: Chore
+description: 설정, 빌드, 패키지, 기타 유지보수 작업을 등록합니다.
+title: "[Chore] "
+labels: ["chore"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 작업 내용
+      description: 해야 할 작업을 설명해주세요.
+      placeholder: 예) ESLint 설정을 프로젝트 규칙에 맞게 조정합니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 작업 이유
+      description: 이 작업이 필요한 이유를 작성해주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: todo
+    attributes:
+      label: TODO
+      description: 작업 항목을 체크리스트로 작성해주세요.
+      placeholder: |
+        - [ ] 설정 파일 수정
+        - [ ] 불필요한 의존성 정리
+        - [ ] 빌드 확인
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 검증 방법
+      description: 작업 후 어떻게 검증할지 작성해주세요.
+      placeholder: 예) npm run lint와 npm run build를 실행합니다.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,45 @@
+name: Docs
+description: 문서 작업을 등록합니다.
+title: "[Docs] "
+labels: ["docs"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 문서 작업 내용
+      description: 작성하거나 수정할 문서 내용을 설명해주세요.
+      placeholder: 예) 프로젝트 실행 방법과 브랜치 전략을 README에 추가합니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: target
+    attributes:
+      label: 문서 위치
+      description: 수정할 문서 파일이나 추가할 문서 위치를 작성해주세요.
+      placeholder: |
+        - README.md
+        - AGENTS.md
+        - docs/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: todo
+    attributes:
+      label: TODO
+      description: 문서 작업 항목을 체크리스트로 작성해주세요.
+      placeholder: |
+        - [ ] 실행 방법 정리
+        - [ ] 환경 변수 설명 추가
+        - [ ] 브랜치 전략 설명 추가
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 참고 자료
+      description: 참고할 링크나 기존 문서가 있다면 첨부해주세요.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,50 @@
+name: Feature
+description: 새로운 기능을 등록합니다.
+title: "[Feature] "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 기능 설명
+      description: 추가하려는 기능을 간단히 설명해주세요.
+      placeholder: 예) 사용자가 테마를 좋아요 순으로 정렬할 수 있게 합니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 필요한 이유
+      description: 이 기능이 왜 필요한지 설명해주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: 요구사항
+      description: 구현되어야 하는 내용을 체크리스트로 작성해주세요.
+      placeholder: |
+        - [ ] 요구사항 1
+        - [ ] 요구사항 2
+        - [ ] 요구사항 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 완료 기준
+      description: 이 이슈가 완료되었다고 판단할 수 있는 기준을 작성해주세요.
+      placeholder: 예) 사용자가 테마 목록에서 정렬 옵션을 선택할 수 있다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 참고 자료
+      description: 참고 이미지, 링크, 디자인 등이 있다면 첨부해주세요.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,54 @@
+name: Refactor
+description: 리팩토링 또는 버그 해결 작업을 등록합니다.
+title: "[Refactor] "
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 작업 설명
+      description: 리팩토링하거나 해결하려는 문제를 설명해주세요.
+      placeholder: 예) 테마 목록 필터링 로직을 커스텀 훅으로 분리합니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 작업 이유
+      description: 이 작업이 필요한 이유를 작성해주세요.
+      placeholder: 예) 컴포넌트가 상태 관리와 렌더링을 함께 담당하고 있어 유지보수가 어렵습니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 변경 범위
+      description: 수정할 파일, 컴포넌트, 로직 범위를 작성해주세요.
+      placeholder: |
+        - src/pages/theme-community/List.tsx
+        - src/services/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: todo
+    attributes:
+      label: TODO
+      description: 작업 항목을 체크리스트로 작성해주세요.
+      placeholder: |
+        - [ ] 중복 로직 정리
+        - [ ] 버그 원인 수정
+        - [ ] 기존 동작 유지 확인
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 검증 방법
+      description: 작업 후 어떻게 검증할지 작성해주세요.
+      placeholder: 예) npm run build 실행 후 관련 화면에서 기존 동작과 버그 해결 여부를 확인합니다.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/style.yml
+++ b/.github/ISSUE_TEMPLATE/style.yml
@@ -1,0 +1,51 @@
+name: Style
+description: CSS 또는 스타일만 변경하는 작업을 등록합니다.
+title: "[Style] "
+labels: ["style"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 스타일 변경 내용
+      description: 변경하려는 스타일을 설명해주세요.
+      placeholder: 예) 전역 버튼 포커스 스타일을 디자인 시스템 기준에 맞게 조정합니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: target
+    attributes:
+      label: 변경 대상
+      description: 스타일을 변경할 화면, 컴포넌트, 전역 스타일 범위를 작성해주세요.
+      placeholder: |
+        - 전역 스타일
+        - 공통 버튼 컴포넌트
+        - 테마 목록 페이지
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 변경 이유
+      description: 스타일 변경이 필요한 이유를 작성해주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: 제한 사항
+      description: 기능 로직 변경 없이 스타일만 변경해야 하는 등 주의할 점을 작성해주세요.
+      placeholder: 예) API 호출, 상태 관리, 라우팅 로직은 변경하지 않습니다.
+    validations:
+      required: false
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 확인 방법
+      description: 스타일 변경 후 확인할 화면이나 뷰포트를 작성해주세요.
+      placeholder: 예) 모바일/데스크톱에서 버튼 포커스 스타일과 레이아웃 깨짐 여부를 확인합니다.
+    validations:
+      required: true


### PR DESCRIPTION
1. GitHub Issue Form 템플릿을 feature, refactor, style, docs, chore, bug report로 분리
2. 각 템플릿에 작업 설명, 변경 범위, TODO, 검증 방법 등 입력 항목 추가
3. config.yml에서 빈 이슈 생성을 허용하도록 설정