### PR TITLE
refactor: 로그인 분리 깃헙 이슈 템플릿 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -22,17 +22,6 @@ body:
       required: true
 
   - type: textarea
-    id: scope
-    attributes:
-      label: 변경 범위
-      description: 수정할 파일, 컴포넌트, 로직 범위를 작성해주세요.
-      placeholder: |
-        - src/pages/theme-community/List.tsx
-        - src/services/...
-    validations:
-      required: true
-
-  - type: textarea
     id: todo
     attributes:
       label: TODO

--- a/.github/ISSUE_TEMPLATE/style.yml
+++ b/.github/ISSUE_TEMPLATE/style.yml
@@ -13,18 +13,6 @@ body:
       required: true
 
   - type: textarea
-    id: target
-    attributes:
-      label: 변경 대상
-      description: 스타일을 변경할 화면, 컴포넌트, 전역 스타일 범위를 작성해주세요.
-      placeholder: |
-        - 전역 스타일
-        - 공통 버튼 컴포넌트
-        - 테마 목록 페이지
-    validations:
-      required: true
-
-  - type: textarea
     id: reason
     attributes:
       label: 변경 이유

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -13,9 +13,17 @@ interface ILoginFormProps {
   errors: FieldErrors<ILoginFormData>;
   isSubmitting: boolean;
   onKakaoLogin: () => void;
+  isLocalLoginEnabled: boolean;
 }
 
-export default function LoginForm({ register, onSubmit, errors, isSubmitting, onKakaoLogin }: ILoginFormProps) {
+export default function LoginForm({
+  register,
+  onSubmit,
+  errors,
+  isSubmitting,
+  onKakaoLogin,
+  isLocalLoginEnabled,
+}: ILoginFormProps) {
   return (
     <div className="relative flex h-full flex-col overflow-hidden bg-gradient-to-b from-white via-[#f0f5ff] to-[#dce8ff]">
       {/* 로고 영역 */}
@@ -33,51 +41,57 @@ export default function LoginForm({ register, onSubmit, errors, isSubmitting, on
       </div>
 
       {/* 폼 영역 */}
-      <form onSubmit={onSubmit} className="flex flex-col gap-3 px-8 pb-44">
-        <input
-          type="text"
-          placeholder="이메일"
-          aria-label="이메일"
-          {...register('email', { required: true })}
-          className="w-full rounded-xl border border-secondary-300 bg-white px-4 py-3 text-[14px] shadow-sm outline-none focus:border-primary"
-        />
-        <input
-          type="password"
-          placeholder="비밀번호"
-          aria-label="비밀번호"
-          {...register('password', { required: true })}
-          className="w-full rounded-xl border border-secondary-300 bg-white px-4 py-3 text-[14px] shadow-sm outline-none focus:border-primary"
-        />
-        {errors.root && (
-          <p className="text-center text-[12px] text-red-500">{errors.root.message}</p>
-        )}
-        <Button type="submit" isFullWidth disabled={isSubmitting} className="mt-1 shadow-sm">
-          {isSubmitting ? '로그인 중...' : '로그인'}
-        </Button>
-        <p className="text-center text-[13px] text-gray-400">
-          계정이 없으신가요?{' '}
-          <Link to="/signup" className="font-semibold text-primary">
-            회원가입
-          </Link>
-        </p>
+      <div className="flex flex-col gap-3 px-8 pb-44">
+        {isLocalLoginEnabled && (
+          <>
+            <form onSubmit={onSubmit} className="flex flex-col gap-3">
+              <input
+                type="text"
+                placeholder="이메일"
+                aria-label="이메일"
+                {...register('email', { required: true })}
+                className="w-full rounded-xl border border-secondary-300 bg-white px-4 py-3 text-[14px] shadow-sm outline-none focus:border-primary"
+              />
+              <input
+                type="password"
+                placeholder="비밀번호"
+                aria-label="비밀번호"
+                {...register('password', { required: true })}
+                className="w-full rounded-xl border border-secondary-300 bg-white px-4 py-3 text-[14px] shadow-sm outline-none focus:border-primary"
+              />
+              {errors.root && (
+                <p className="text-center text-[12px] text-red-500">{errors.root.message}</p>
+              )}
+              <Button type="submit" isFullWidth disabled={isSubmitting} className="mt-1 shadow-sm">
+                {isSubmitting ? '로그인 중...' : '로그인'}
+              </Button>
+              <p className="text-center text-[13px] text-gray-400">
+                계정이 없으신가요?{' '}
+                <Link to="/signup" className="font-semibold text-primary">
+                  회원가입
+                </Link>
+              </p>
+            </form>
 
-        {/* 구분선 */}
-        <div className="flex items-center gap-3">
-          <div className="h-px flex-1 bg-gray-200" />
-          <span className="text-[12px] text-gray-400">또는</span>
-          <div className="h-px flex-1 bg-gray-200" />
-        </div>
+            {/* 구분선 */}
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-gray-200" />
+              <span className="text-[12px] text-gray-400">또는</span>
+              <div className="h-px flex-1 bg-gray-200" />
+            </div>
+          </>
+        )}
 
         {/* 카카오 로그인 버튼 */}
         <button
           type="button"
           onClick={onKakaoLogin}
-          className="flex w-full items-center justify-center gap-2 rounded-xl bg-[#FEE500] py-3 text-[14px] font-semibold text-[#191919] shadow-sm"
+          className="relative z-[999] flex w-full items-center justify-center gap-2 rounded-xl bg-[#FEE500] py-3 text-[14px] font-semibold text-[#191919] shadow-sm"
         >
           <KakaoLogo className="h-5 w-5" />
           카카오로 로그인
         </button>
-      </form>
+      </div>
 
       {/* 하단 우측 일러스트 */}
       <div className="absolute bottom-0 right-0">

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -5,6 +5,9 @@ import LoginForm from '../../components/auth/LoginForm';
 export default function Login() {
   const { register, onSubmit, errors, isSubmitting } = useLogin();
   const { handleKakaoLogin } = useKakaoLogin();
+  const localLoginEnv = import.meta.env.VITE_ENABLE_LOCAL_LOGIN;
+  const isLocalLoginEnabled =
+    localLoginEnv === 'true' || (localLoginEnv !== 'false' && import.meta.env.DEV);
 
   return (
     <LoginForm
@@ -13,6 +16,7 @@ export default function Login() {
       errors={errors}
       isSubmitting={isSubmitting}
       onKakaoLogin={handleKakaoLogin}
+      isLocalLoginEnabled={isLocalLoginEnabled}
     />
   );
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,7 @@
 // src/vite-env.d.ts
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_LOCAL_LOGIN?: string;
+}


### PR DESCRIPTION
- VITE_ENABLE_LOCAL_LOGIN 환경 변수로 로컬 로그인 노출 여부를 제어
- 로컬 로그인 폼, 회원가입 링크, 구분선을 조건부 렌더링하도록 변경
- 카카오 로그인 버튼이 하단 일러스트에 가려지지 않도록 z-index 조정
- production build에서는 기본적으로 소셜 로그인만 노출되도록 설정
- refactor 템플릿에서 변경 범위 입력 항목 제거
- style 템플릿에서 변경 대상 입력 항목 제거